### PR TITLE
Establish LocalDeployerAutoConfiguration creation order

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerAutoConfiguration.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerAutoConfiguration.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Mark Fisher
  */
 @Configuration
-@EnableConfigurationProperties(LocalDeployerProperties.class)
+@AutoConfigureBefore(name = "org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration")
 public class LocalDeployerAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerAutoConfiguration.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -29,7 +28,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Mark Fisher
  */
 @Configuration
-@AutoConfigureBefore(name = "org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration")
 public class LocalDeployerAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
It should be created prior to utilized prior to DataFlowControllerAutoConfiguration

This is to prevent the following exception:
[org.springframework.cloud.deployer.spi.local.LocalDeployerProperties] is defined: expected single matching bean but found 2: localDeployerProperties,deployer.local.CONFIGURATION_PROPERTIES