### PR TITLE
DO NOT MERGE async deployer poc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
+		<reactor.version>2.5.0.M2</reactor.version>
 	</properties>
 
 	<modules>
@@ -35,6 +36,11 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>io.projectreactor</groupId>
+				<artifactId>reactor-core</artifactId>
+				<version>${reactor.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
@@ -102,5 +108,17 @@
 			</pluginRepositories>
 		</profile>
 	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/spring-cloud-deployer-spi/pom.xml
+++ b/spring-cloud-deployer-spi/pom.xml
@@ -20,6 +20,10 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -16,7 +16,15 @@
 
 package org.springframework.cloud.deployer.spi.app;
 
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * SPI defining a runtime environment capable of deploying and managing the
@@ -56,6 +64,10 @@ public interface AppDeployer {
 	 */
 	String deploy(AppDeploymentRequest request);
 
+	// deploy reactor vs jdk8
+	Mono<String> deployAsync1(AppDeploymentRequest request);
+	CompletableFuture<String> deployAsync2(AppDeploymentRequest request);
+
 	/**
 	 * Un-deploy an app using its deployment id. Implementations may perform
 	 * this operation asynchronously; therefore a successful un-deployment may
@@ -67,6 +79,10 @@ public interface AppDeployer {
 	 */
 	void undeploy(String id);
 
+	// undeploy reactor vs jdk8
+	Mono<Void> undeployAsync1(String id);
+	CompletableFuture<Void> undeployAsync2(String id);
+
 	/**
 	 * Return the {@link AppStatus} for an app represented by a deployment id.
 	 *
@@ -74,4 +90,15 @@ public interface AppDeployer {
 	 * @return the app deployment status
 	 */
 	AppStatus status(String id);
+
+	// status reactor vs jdk8
+	Mono<AppStatus> statusAsync1(String id);
+	CompletableFuture<AppStatus> statusAsync2(String id);
+
+	// statuses reactor vs jdk8
+	Flux<AppStatus> statusAsync1(Collection<String> ids);
+	Stream<AppStatus> statusAsync2(Collection<String> ids);
+
+	// reactor statuses as flux out, publisher in
+	Flux<AppStatus> statusAsync1(Publisher<String> ids);
 }


### PR DESCRIPTION
This is a little async comparison for reactor Mono/Flux vs jdk8 CompletableFuture/Stream.
- Just for review!!!
- Quick hacking, just adding new methods to SPI to see how things looks like!!!
- New methods having `1` is for reactor, methods with `2` is for jdk8.
- Imho, reactor is much _nicer_ to use, jdk8 just feels awkard.
- `CompletableFuture` does its stuff immediately and not like reactor which does it
  stuff when there's demand. So with jdk8, no backpressure support.
