### PR TITLE
[For discussion] Basic debug support for local deployer

### DIFF
--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
  * @author Patrick Peralta
  * @author Marius Bogoevici
  * @author Janne Valkealahti
+ * @author Andy Clement
  */
 public interface AppDeployer {
 
@@ -36,6 +37,12 @@ public interface AppDeployer {
 	 */
 	public static String COUNT_PROPERTY_KEY = "spring.cloud.deployer.count";
 
+	/**
+	 * The environment property for the debug port. Setting this implies
+	 * debugging should be enabled.
+	 */
+	public static String DEBUG_PORT_PROPERTY_KEY = "spring.cloud.deployer.debug-port";
+	
 	/**
 	 * The environment property for the group to which an app belongs.
 	 */


### PR DESCRIPTION
Created two pull requests (one here on the deployer, the other on dataflow), these are for github issue https://github.com/spring-cloud/spring-cloud-dataflow/issues/369 "Add debug capabilities to LocalAppDeployer".

With these two in place you can turn on debug by specifying "module.foo.debug-port=8800" as a deployment property.

The first pull request (on the deployer) recognizes a debug-port property and uses it to add a debug agent to the configuration for the Process it launches. 

The second pull request (on dataflow) recognizes the deployment pattern module.<xxx>.debug-port=XXX and maps that to the debug-port property in the deployer.

This works but are the properties in the right place? Is it ok to have this as a deployment config property? (It is quite nice that turning debug on/off does not require meddling with the stream definition). What do we do for other deployers? Do we need a simpler 'debug=true/false' option alongside this for any that don't need a port, or do we need a deployer specific namespace subsection for this?
