### PR TITLE
Add option for command line args

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.local;
+
+import java.util.ArrayList;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.util.Assert;
+
+/**
+ * Base class for app deployer and task launcher providing
+ * support for common functionality.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class AbstractDeployerSupport {
+
+	private final LocalDeployerProperties properties;
+
+	/**
+	 * Instantiates a new abstract deployer support.
+	 *
+	 * @param properties the local deployer properties
+	 */
+	public AbstractDeployerSupport(LocalDeployerProperties properties) {
+		Assert.notNull(properties, "LocalDeployerProperties must not be null");
+		this.properties = properties;
+	}
+
+	/**
+	 * Gets the local deployer properties.
+	 *
+	 * @return the local deployer properties
+	 */
+	protected LocalDeployerProperties getLocalDeployerProperties() {
+		return properties;
+	}
+
+	/**
+	 * Builds the jar execution command.
+	 *
+	 * @param jarPath the jar path
+	 * @param request the request
+	 * @return the string[]
+	 */
+	protected String[] buildJarExecutionCommand(String jarPath, AppDeploymentRequest request) {
+		ArrayList<String> commands = new ArrayList<String>();
+		commands.add(properties.getJavaCmd());
+		commands.add("-Dfile.encoding=UTF-8");
+		commands.add("-jar");
+		commands.add(jarPath);
+		commands.addAll(request.getCommandlineArguments());
+		return commands.toArray(new String[0]);
+	}
+}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
@@ -46,7 +46,7 @@ public abstract class AbstractDeployerSupport {
 	 *
 	 * @return the local deployer properties
 	 */
-	protected LocalDeployerProperties getLocalDeployerProperties() {
+	final protected LocalDeployerProperties getLocalDeployerProperties() {
 		return properties;
 	}
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -36,14 +36,12 @@ import javax.annotation.PreDestroy;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.Resource;
-import org.springframework.util.Assert;
 import org.springframework.util.SocketUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
@@ -56,8 +54,9 @@ import org.springframework.web.client.RestTemplate;
  * @author Marius Bogoevici
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
-public class LocalAppDeployer implements AppDeployer {
+public class LocalAppDeployer extends AbstractDeployerSupport implements AppDeployer {
 
 	private Path logPathRoot;
 
@@ -80,15 +79,17 @@ public class LocalAppDeployer implements AppDeployer {
 		}
 	}
 
-	private final LocalDeployerProperties properties;
-
 	private final Map<String, List<Instance>> running = new ConcurrentHashMap<>();
 
 	private final RestTemplate restTemplate = new RestTemplate();
 
+	/**
+	 * Instantiates a new local app deployer.
+	 *
+	 * @param properties the properties
+	 */
 	public LocalAppDeployer(LocalDeployerProperties properties) {
-		Assert.notNull(properties, "LocalDeployerProperties must not be null");
-		this.properties = properties;
+		super(properties);
 		try {
 			this.logPathRoot = Files.createTempDirectory(properties.getWorkingDirectoriesRoot(), "spring-cloud-dataflow-");
 		}
@@ -133,7 +134,7 @@ public class LocalAppDeployer implements AppDeployer {
 			}
 			Path workDir = Files
 					.createDirectory(Paths.get(deploymentGroupDir.toFile().getAbsolutePath(), deploymentId));
-			if (properties.isDeleteFilesOnExit()) {
+			if (getLocalDeployerProperties().isDeleteFilesOnExit()) {
 				workDir.toFile().deleteOnExit();
 			}
 			String countProperty = request.getEnvironmentProperties().get(COUNT_PROPERTY_KEY);
@@ -144,12 +145,12 @@ public class LocalAppDeployer implements AppDeployer {
 				if (useDynamicPort) {
 					args.put(SERVER_PORT_KEY, String.valueOf(port));
 				}
-				ProcessBuilder builder = new ProcessBuilder(properties.getJavaCmd(), "-Dfile.encoding=UTF-8", "-jar", jarPath);
+				ProcessBuilder builder = new ProcessBuilder(buildJarExecutionCommand(jarPath, request));
 				builder.environment().keySet().retainAll(ENV_VARS_TO_INHERIT);
 				builder.environment().putAll(args);
 				Instance instance = new Instance(deploymentId, i, builder, workDir, port);
 				processes.add(instance);
-				if (properties.isDeleteFilesOnExit()) {
+				if (getLocalDeployerProperties().isDeleteFilesOnExit()) {
 					instance.stdout.deleteOnExit();
 					instance.stderr.deleteOnExit();
 				}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -16,13 +16,31 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.deployed;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
+import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.test.AbstractAppDeployerIntegrationTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 
 /**
  * Integration tests for {@link LocalAppDeployer}.
@@ -33,12 +51,48 @@ import org.springframework.context.annotation.Configuration;
 @SpringApplicationConfiguration(classes = LocalAppDeployerIntegrationTests.Config.class)
 public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
 
+	private static final Logger log = LoggerFactory.getLogger(LocalAppDeployerIntegrationTests.class);
+
 	@Autowired
 	private AppDeployer appDeployer;
 
 	@Override
 	protected AppDeployer appDeployer() {
 		return appDeployer;
+	}
+
+	@Test
+	public void testArgumentsPassing() {
+		// this test simple tries to pass arguments as
+		// we don't have no way to read logs to verify output
+		AppDefinition definition = new AppDefinition(randomName(), null);
+		Resource resource = integrationTestProcessor();
+		Set<String> arguments = new HashSet<String>();
+		arguments.add("--foo.bar=jee");
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, null, arguments);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+
+		String deploymentId = appDeployer().deploy(request);
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Deploying {} again...", request.getDefinition().getName());
+
+		try {
+			appDeployer().deploy(request);
+			fail("Should have thrown an IllegalStateException");
+		}
+		catch (IllegalStateException ok) {
+		}
+
+		log.info("Undeploying {}...", deploymentId);
+
+		timeout = undeploymentTimeout();
+		appDeployer().undeploy(deploymentId);
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
 	}
 
 	@Configuration

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -23,8 +23,8 @@ import static org.springframework.cloud.deployer.spi.app.DeploymentState.deploye
 import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
 import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 		// we don't have no way to read logs to verify output
 		AppDefinition definition = new AppDefinition(randomName(), null);
 		Resource resource = integrationTestProcessor();
-		Set<String> arguments = new HashSet<String>();
+		List<String> arguments = new ArrayList<String>();
 		arguments.add("--foo.bar=jee");
 		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, null, arguments);
 

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/core/AppDeploymentRequest.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/core/AppDeploymentRequest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.deployer.spi.core;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -35,6 +36,9 @@ import org.springframework.util.Assert;
  *
  * For passing properties or parameters into the app itself, use
  * {@link AppDefinition#getProperties()}.
+ *
+ * For passing command line arguments into the app itself, use
+ * {@link #commandlineArguments}.
  *
  * @author Mark Fisher
  * @author Janne Valkealahti
@@ -57,6 +61,11 @@ public class AppDeploymentRequest {
 	private final Map<String, String> environmentProperties;
 
 	/**
+	 * Set of command line arguments for the target runtime of the app.
+	 */
+	private final Set<String> commandlineArguments;
+
+	/**
 	 * Construct an {@code AppDeploymentRequest}.
 	 *
 	 * @param definition app definition
@@ -65,6 +74,19 @@ public class AppDeploymentRequest {
 	 */
 	public AppDeploymentRequest(AppDefinition definition, Resource resource,
 			Map<String, String> environmentProperties) {
+		this(definition, resource, environmentProperties, null);
+	}
+
+	/**
+	 * Construct an {@code AppDeploymentRequest}.
+	 *
+	 * @param definition app definition
+	 * @param resource resource for the underlying app's artifact
+	 * @param environmentProperties map of environment properties; may be {@code null}
+	 * @param commandlineArguments set of command line arguments; may be {@code null}
+	 */
+	public AppDeploymentRequest(AppDefinition definition, Resource resource,
+			Map<String, String> environmentProperties, Set<String> commandlineArguments) {
 		Assert.notNull(definition, "definition must not be null");
 		Assert.notNull(resource, "resource must not be null");
 		this.definition = definition;
@@ -72,6 +94,9 @@ public class AppDeploymentRequest {
 		this.environmentProperties = environmentProperties == null
 				? Collections.<String, String>emptyMap()
 				: Collections.unmodifiableMap(environmentProperties);
+		this.commandlineArguments = commandlineArguments == null
+				? Collections.<String>emptySet()
+				: Collections.unmodifiableSet(commandlineArguments);
 	}
 
 	/**
@@ -103,5 +128,12 @@ public class AppDeploymentRequest {
 	 */
 	public Map<String, String> getEnvironmentProperties() {
 		return environmentProperties;
+	}
+
+	/**
+	 * @see #commandlineArguments
+	 */
+	public Set<String> getCommandlineArguments() {
+		return commandlineArguments;
 	}
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/core/AppDeploymentRequest.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/core/AppDeploymentRequest.java
@@ -17,8 +17,8 @@
 package org.springframework.cloud.deployer.spi.core;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -61,9 +61,9 @@ public class AppDeploymentRequest {
 	private final Map<String, String> environmentProperties;
 
 	/**
-	 * Set of command line arguments for the target runtime of the app.
+	 * List of command line arguments for the target runtime of the app.
 	 */
-	private final Set<String> commandlineArguments;
+	private final List<String> commandlineArguments;
 
 	/**
 	 * Construct an {@code AppDeploymentRequest}.
@@ -86,7 +86,7 @@ public class AppDeploymentRequest {
 	 * @param commandlineArguments set of command line arguments; may be {@code null}
 	 */
 	public AppDeploymentRequest(AppDefinition definition, Resource resource,
-			Map<String, String> environmentProperties, Set<String> commandlineArguments) {
+			Map<String, String> environmentProperties, List<String> commandlineArguments) {
 		Assert.notNull(definition, "definition must not be null");
 		Assert.notNull(resource, "resource must not be null");
 		this.definition = definition;
@@ -95,8 +95,8 @@ public class AppDeploymentRequest {
 				? Collections.<String, String>emptyMap()
 				: Collections.unmodifiableMap(environmentProperties);
 		this.commandlineArguments = commandlineArguments == null
-				? Collections.<String>emptySet()
-				: Collections.unmodifiableSet(commandlineArguments);
+				? Collections.<String>emptyList()
+				: Collections.unmodifiableList(commandlineArguments);
 	}
 
 	/**
@@ -133,7 +133,7 @@ public class AppDeploymentRequest {
 	/**
 	 * @see #commandlineArguments
 	 */
-	public Set<String> getCommandlineArguments() {
+	public List<String> getCommandlineArguments() {
 		return commandlineArguments;
 	}
 }


### PR DESCRIPTION
- AppDeploymentRequest now has commandlineArguments
  as Set.
- Small refactoring by adding shared AbstractDeployerSupport
  for LocalAppDeployer and LocalTaskLauncher.
- Only supports arbitrary java arguments, not options which
  should go between `java` and `-jar`. Arguments are placed after
  `java -jar awesomefat.jar` as is.
- We don't have a proper way to test argument passing
  as we can't read stdout/stderr in tests, otherwise
  using i.e. timestamp task would be easy to verify
  correct passing via its `format` option.
- Actual integration in a dataflow side will be done
  in github.com/spring-cloud/spring-cloud-dataflow/issues/503.
- Fixes #20