### PR TITLE
Add cache to DelegatingResourceLoader

### DIFF
--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -16,31 +16,67 @@
 
 package org.springframework.cloud.deployer.resource.support;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.FileCopyUtils;
 
 /**
  * A {@link ResourceLoader} implementation that delegates to other {@link ResourceLoader} instances
  * that are stored in a Map with their associated URI schemes as the keys.
  *
+ * This implementation is also caching remote resources which are not directly accessible
+ * as {@link File} into either a given cache directory or on default a temporary location
+ * prefixed by "dataflow-resource-cache".
+ *
  * @author Mark Fisher
+ * @author Janne Valkealahti
  */
 public class DelegatingResourceLoader implements ResourceLoader {
+
+	private static final Logger logger = LoggerFactory.getLogger(DelegatingResourceLoader.class);
 
 	private final ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 
 	private final Map<String, ResourceLoader> loaders;
 
+	private final File cacheDirectory;
+
+	private final static String DEFAULT_CACHE_PREFIX = "dataflow-resource-cache";
+
+	/**
+	 * Instantiates a new delegating resource loader.
+	 *
+	 * @param loaders the loaders
+	 */
 	public DelegatingResourceLoader(Map<String, ResourceLoader> loaders) {
+		this(loaders, null);
+	}
+
+	/**
+	 * Instantiates a new delegating resource loader.
+	 *
+	 * @param loaders the loaders
+	 * @param cacheDirectory the cache directory
+	 */
+	public DelegatingResourceLoader(Map<String, ResourceLoader> loaders, File cacheDirectory) {
 		Assert.notEmpty(loaders, "at least one ResourceLoader is required");
 		this.loaders = Collections.unmodifiableMap(loaders);
+		this.cacheDirectory = initCacheDirectory(cacheDirectory);
 	}
 
 	@Override
@@ -51,9 +87,24 @@ public class DelegatingResourceLoader implements ResourceLoader {
 			Assert.notNull(scheme, "a scheme (prefix) is required");
 			ResourceLoader loader = this.loaders.get(scheme);
 			Assert.notNull(loader, String.format("no ResourceLoader available for scheme: %s", scheme));
-			return loader.getResource(location);
+
+			Resource resource = loader.getResource(location);
+			if (existsAsFile(resource)) {
+				return resource;
+			} else {
+				File cachedResource = new File(cacheDirectory, resource.getFilename());
+				if (!cachedResource.exists()) {
+					logger.info("Caching file {} as given location {}", cachedResource, location);
+					FileCopyUtils.copy(resource.getInputStream(), new FileOutputStream(cachedResource));
+				} else {
+					logger.info("Reusing cached file {} as given location {}", cachedResource, location);
+				}
+				return new FileSystemResource(cachedResource);
+			}
 		}
 		catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
+		} catch (IOException e) {
 			throw new IllegalArgumentException(e);
 		}
 	}
@@ -63,4 +114,38 @@ public class DelegatingResourceLoader implements ResourceLoader {
 		return this.classLoader;
 	}
 
+	/**
+	 * Handles init operation of a local cache directory.
+	 *
+	 * @param cacheDirectory the cache directory
+	 * @return the directory
+	 */
+	private File initCacheDirectory(File cacheDirectory) {
+		try {
+			if (cacheDirectory == null) {
+				Path tempDirectory = Files.createTempDirectory(DEFAULT_CACHE_PREFIX);
+				return tempDirectory.toFile();
+			} else {
+				cacheDirectory.mkdirs();
+				return cacheDirectory;
+			}
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Unable to create cache directory", e);
+		}
+	}
+
+	/**
+	 * Check if a resource exists as a file.
+	 *
+	 * @param resource the resource
+	 * @return true, if resource can be accessed as file
+	 */
+	private static boolean existsAsFile(Resource resource) {
+		try {
+			resource.getFile();
+			return true;
+		} catch (IOException e) {
+		}
+		return false;
+	}
 }

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -91,12 +92,14 @@ public class DelegatingResourceLoader implements ResourceLoader {
 			Resource resource = loader.getResource(location);
 			if (existsAsFile(resource)) {
 				return resource;
-			} else {
+			}
+			else {
 				File cachedResource = new File(cacheDirectory, resource.getFilename());
 				if (!cachedResource.exists()) {
 					logger.info("Caching file {} as given location {}", cachedResource, location);
 					FileCopyUtils.copy(resource.getInputStream(), new FileOutputStream(cachedResource));
-				} else {
+				}
+				else {
 					logger.info("Reusing cached file {} as given location {}", cachedResource, location);
 				}
 				return new FileSystemResource(cachedResource);
@@ -104,8 +107,9 @@ public class DelegatingResourceLoader implements ResourceLoader {
 		}
 		catch (URISyntaxException e) {
 			throw new IllegalArgumentException(e);
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e);
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
 		}
 	}
 
@@ -125,11 +129,13 @@ public class DelegatingResourceLoader implements ResourceLoader {
 			if (cacheDirectory == null) {
 				Path tempDirectory = Files.createTempDirectory(DEFAULT_CACHE_PREFIX);
 				return tempDirectory.toFile();
-			} else {
+			}
+			else {
 				cacheDirectory.mkdirs();
 				return cacheDirectory;
 			}
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new IllegalArgumentException("Unable to create cache directory", e);
 		}
 	}
@@ -144,7 +150,8 @@ public class DelegatingResourceLoader implements ResourceLoader {
 		try {
 			resource.getFile();
 			return true;
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 		}
 		return false;
 	}

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -41,7 +41,7 @@ import org.springframework.util.FileCopyUtils;
  *
  * This implementation is also caching remote resources which are not directly accessible
  * as {@link File} into either a given cache directory or on default a temporary location
- * prefixed by "dataflow-resource-cache".
+ * prefixed by "deployer-resource-cache".
  *
  * @author Mark Fisher
  * @author Janne Valkealahti
@@ -56,7 +56,7 @@ public class DelegatingResourceLoader implements ResourceLoader {
 
 	private final File cacheDirectory;
 
-	private final static String DEFAULT_CACHE_PREFIX = "dataflow-resource-cache";
+	private final static String DEFAULT_CACHE_PREFIX = "deployer-resource-cache";
 
 	/**
 	 * Instantiates a new delegating resource loader.

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -94,7 +94,8 @@ public class DelegatingResourceLoader implements ResourceLoader {
 				return resource;
 			}
 			else {
-				File cachedResource = new File(cacheDirectory, resource.getFilename());
+				String cacheName = scheme + "-" + ShaUtils.sha1(location) + "-" + resource.getFilename();
+				File cachedResource = new File(cacheDirectory, cacheName);
 				if (!cachedResource.exists()) {
 					logger.info("Caching file {} as given location {}", cachedResource, location);
 					FileCopyUtils.copy(resource.getInputStream(), new FileOutputStream(cachedResource));

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/ShaUtils.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/ShaUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.resource.support;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Simple sha utils.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class ShaUtils {
+
+	private static final char[] CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+	/**
+	 * Creates a sha1 out from a given data.
+	 *
+	 * @param data the data
+	 * @return the sha1 for data
+	 */
+	protected static String sha1(String data) {
+		try {
+			return new String(encodeHex(MessageDigest.getInstance("SHA-1").digest(data.getBytes("UTF-8"))));
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException(e);
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * Encode given data as lower case hex chars.
+	 *
+	 * @param data the data
+	 * @return the endoced chars
+	 */
+	private static char[] encodeHex(final byte[] data) {
+		final int len = data.length;
+		final char[] out = new char[len << 1];
+		for (int i = 0, j = 0; i < len; i++) {
+			out[j++] = CHARS[(0xF0 & data[i]) >>> 4];
+			out[j++] = CHARS[0x0F & data[i]];
+		}
+		return out;
+	}
+}

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/ShaUtils.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/ShaUtils.java
@@ -40,10 +40,10 @@ public abstract class ShaUtils {
 			return new String(encodeHex(MessageDigest.getInstance("SHA-1").digest(data.getBytes("UTF-8"))));
 		}
 		catch (NoSuchAlgorithmException e) {
-			throw new IllegalArgumentException(e);
+			throw new IllegalStateException(e);
 		}
 		catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException(e);
+			throw new IllegalStateException(e);
 		}
 	}
 

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -16,23 +16,36 @@
 
 package org.springframework.cloud.deployer.resource.support;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
-
+import org.junit.rules.TemporaryFolder;
 import org.springframework.cloud.deployer.resource.StubResourceLoader;
 import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
 /**
+ * Tests for {@link DelegatingResourceLoader}.
+ *
  * @author Patrick Peralta
+ * @author Janne Valkealahti
  */
 public class DelegatingResourceLoaderTests {
+
+	private final static String HTTP_RESOURCE = "http://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom";
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Test
 	public void test() {
@@ -54,6 +67,26 @@ public class DelegatingResourceLoaderTests {
 		assertEquals(three, resourceLoader.getResource("three://three"));
 	}
 
+	@Test
+	public void testDefaultCache() throws IOException {
+		Map<String, ResourceLoader> loaders = new HashMap<>();
+		loaders.put("http", new DefaultResourceLoader());
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(loaders);
+		Resource resource = resourceLoader.getResource(HTTP_RESOURCE);
+		File file = resource.getFile();
+		assertEquals(file.exists(), true);
+	}
+
+	@Test
+	public void testManualCache() throws IOException {
+		Map<String, ResourceLoader> loaders = new HashMap<>();
+		loaders.put("http", new DefaultResourceLoader());
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(loaders, folder.getRoot());
+		Resource resource = resourceLoader.getResource(HTTP_RESOURCE);
+		File file = resource.getFile();
+		assertEquals(file.exists(), true);
+	}
+
 	static class NullResource extends AbstractResource {
 
 		final String description;
@@ -65,6 +98,11 @@ public class DelegatingResourceLoaderTests {
 		@Override
 		public String getDescription() {
 			return description;
+		}
+
+		@Override
+		public File getFile() throws IOException {
+			return null;
 		}
 
 		@Override

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 import org.springframework.cloud.deployer.resource.StubResourceLoader;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.DefaultResourceLoader;

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/ShaUtilsTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/ShaUtilsTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.resource.support;
+
+import static org.junit.Assert.assertEquals;
+
+import java.security.SecureRandom;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Simple sha utils tests.
+ *
+ * @author Janne Valkealahti
+ */
+public class ShaUtilsTests {
+
+	@Test
+	public void testSimpleSmoke() {
+		for (int j = 0; j < 100; j++) {
+			Set<String> nodups = new HashSet<>();
+			for (int i = 0; i < 1000; i++) {
+				nodups.add(ShaUtils.sha1(randomString(20)));
+			}
+			assertEquals(nodups.size() == 1000, true);
+		}
+	}
+
+	static final String CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!£$%^&*()-=+_";
+	static SecureRandom rnd = new SecureRandom();
+
+	String randomString(int len) {
+		StringBuilder sb = new StringBuilder(len);
+		for (int i = 0; i < len; i++)
+			sb.append(CHARS.charAt(rnd.nextInt(CHARS.length())));
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
- Add a relatively naive caching into a loader
  so that resources which are not directly available
  as File can be 'cached' from its inputstream and
  then used there as a direct FileSystemResource.
- Cache key is a simple resource filename and thus
  assumes that different resources having same file
  name are identical.
- On default a cache directory is created for every
  instance of a DelegatingResourceLoader, but can be
  manually set via constructor which is something what
  dataflow server can expose as configurable option.
- Fixes #38
- Fixes #39