### PR TITLE
Configurable regex for env var retention

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -41,6 +41,12 @@ public class LocalDeployerProperties {
 	private boolean deleteFilesOnExit = true;
 
 	/**
+	 * Array of regular expression patterns for environment variables that
+	 * should be passed to launched applications.
+	 */
+	private String[] envVarsToInherit = { "TMP", "LANG", "LANGUAGE", "LC_.*" };
+
+	/**
 	 * The command to run java.
 	 */
 	private String javaCmd = "java";
@@ -67,5 +73,13 @@ public class LocalDeployerProperties {
 
 	public void setDeleteFilesOnExit(boolean deleteFilesOnExit) {
 		this.deleteFilesOnExit = deleteFilesOnExit;
+	}
+
+	public String[] getEnvVarsToInherit() {
+		return envVarsToInherit;
+	}
+
+	public void setEnvVarsToInherit(String[] envVarsToInherit) {
+		this.envVarsToInherit = envVarsToInherit;
 	}
 }


### PR DESCRIPTION
Replaced hard coded set of env variables with a configurable string array of regular expressions for var retention.

The check for Windows to include `TMP` was removed for simplicity - is this required or can we include this on other platforms?

This fixes https://github.com/spring-cloud/spring-cloud-deployer/issues/25.