### PR TITLE
Guard getFile with all exceptions

### DIFF
--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -159,7 +159,7 @@ public class DelegatingResourceLoader implements ResourceLoader {
 			resource.getFile();
 			return true;
 		}
-		catch (IOException e) {
+		catch (Exception e) {
 		}
 		return false;
 	}


### PR DESCRIPTION
- Add better catch in DelegatingResourceLoader
  for existsAsFile().
- Fixes #49