### PR TITLE
LocalTaskLauncher not using parent env

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -26,12 +26,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 
 import javax.annotation.PreDestroy;
 
@@ -138,9 +135,7 @@ public class LocalAppDeployer extends AbstractDeployerSupport implements AppDepl
 				if (useDynamicPort) {
 					args.put(SERVER_PORT_KEY, String.valueOf(port));
 				}
-				ProcessBuilder builder = new ProcessBuilder(buildJarExecutionCommand(jarPath, request));
-				retainEnvVars(builder.environment().keySet());
-				builder.environment().putAll(args);
+				ProcessBuilder builder = buildProcessBuilder(jarPath, request, args);
 				Instance instance = new Instance(deploymentId, i, builder, workDir, port);
 				processes.add(instance);
 				if (getLocalDeployerProperties().isDeleteFilesOnExit()) {
@@ -154,31 +149,6 @@ public class LocalAppDeployer extends AbstractDeployerSupport implements AppDepl
 			throw new RuntimeException("Exception trying to deploy " + request, e);
 		}
 		return deploymentId;
-	}
-
-	/**
-	 * Retain the environment variable strings in the provided set indicated by
-	 * {@link LocalDeployerProperties#getEnvVarsToInherit}.
-	 * This assumes that the provided set can be modified.
-	 *
-	 * @param vars set of environment variable strings
-	 */
-	private void retainEnvVars(Set<String> vars) {
-		String[] patterns = getLocalDeployerProperties().getEnvVarsToInherit();
-
-		for (Iterator<String> iterator = vars.iterator(); iterator.hasNext();) {
-			String var = iterator.next();
-			boolean retain = false;
-			for (String pattern : patterns) {
-				if (Pattern.matches(pattern, var)) {
-					retain = true;
-					break;
-				}
-			}
-			if (!retain) {
-				iterator.remove();
-			}
-		}
 	}
 
 	@Override

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
@@ -118,9 +118,7 @@ public class LocalTaskLauncher extends AbstractDeployerSupport implements TaskLa
 			if (useDynamicPort) {
 				args.put(SERVER_PORT_KEY, String.valueOf(port));
 			}
-			ProcessBuilder builder = new ProcessBuilder(buildJarExecutionCommand(jarPath, request));
-			builder.environment().clear();
-			builder.environment().putAll(args);
+			ProcessBuilder builder = buildProcessBuilder(jarPath, request, args);
 			Instance instance = new Instance(builder, workDir, port);
 			running.put(taskLaunchId, instance);
 			if (getLocalDeployerProperties().isDeleteFilesOnExit()) {


### PR DESCRIPTION
- Refactor LocalTaskLauncher to use same
  ProcessBuilder concepts than LocalAppDeployer.
- Moved some common functionality into a parent
  AbstractDeployerSupport.
- Fixes #42