### PR TITLE
Classpath based application launching

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractDeployerSupport.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.util.Assert;
@@ -60,8 +61,17 @@ public abstract class AbstractDeployerSupport {
 	protected String[] buildJarExecutionCommand(String jarPath, AppDeploymentRequest request) {
 		ArrayList<String> commands = new ArrayList<String>();
 		commands.add(properties.getJavaCmd());
-		commands.add("-jar");
-		commands.add(jarPath);
+
+		Map<String, String> envProps = request.getEnvironmentProperties();
+		if (envProps.containsKey("main") && envProps.containsKey("classpath")) {
+			commands.add("-cp");
+			commands.add(envProps.get("classpath"));
+			commands.add(envProps.get("main"));
+		}
+		else {
+			commands.add("-jar");
+			commands.add(jarPath);
+		}
 		commands.addAll(request.getCommandlineArguments());
 		return commands.toArray(new String[0]);
 	}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.SocketUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
@@ -206,13 +207,40 @@ public class LocalAppDeployer extends AbstractDeployerSupport implements AppDepl
 		return builder.build();
 	}
 
+	/**
+	 * Shut down the {@link Process} backing the application {@link Instance}.
+	 * If the application exposes a {@code /shutdown} endpoint, that will be
+	 * invoked followed by a wait that will not exceed the number of milliseconds
+	 * indicated by {@link LocalDeployerProperties#shutdownTimeout}. If the
+	 * timeout period is exceeded (or if the {@code /shutdown} endpoint is not exposed),
+	 * the process will be shut down via {@link Process#destroy()}.
+	 *
+	 * @param instance the application instance to shut down
+	 */
 	private void shutdownAndWait(Instance instance) {
 		try {
-			restTemplate.postForObject(instance.url + "/shutdown", null, String.class);
-			instance.process.waitFor();
+			int timeout = getLocalDeployerProperties().getShutdownTimeout();
+			if (timeout > 0) {
+				ResponseEntity<String> response = restTemplate.postForEntity(
+						instance.url + "/shutdown", null, String.class);
+				if (response.getStatusCode().is2xxSuccessful()) {
+					long timeoutTimestamp = System.currentTimeMillis() + timeout;
+					while (isAlive(instance.process) && System.currentTimeMillis() < timeoutTimestamp) {
+						Thread.sleep(1000);
+					}
+				}
+			}
 		}
-		catch (InterruptedException | ResourceAccessException e) {
-			instance.process.destroy();
+		catch (ResourceAccessException e) {
+			// ignore I/O errors
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			if (isAlive(instance.process)) {
+				instance.process.destroy();
+			}
 		}
 	}
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -51,6 +51,13 @@ public class LocalDeployerProperties {
 	 */
 	private String javaCmd = "java";
 
+	/**
+	 * Maximum number of milliseconds to wait for application shutdown
+	 * via the {@code /shutdown} endpoint.
+	 */
+	private int shutdownTimeout = 30000;
+
+
 	public String getJavaCmd() {
 		return javaCmd;
 	}
@@ -82,4 +89,14 @@ public class LocalDeployerProperties {
 	public void setEnvVarsToInherit(String[] envVarsToInherit) {
 		this.envVarsToInherit = envVarsToInherit;
 	}
+
+	public int getShutdownTimeout() {
+		return shutdownTimeout;
+	}
+
+	public LocalDeployerProperties setShutdownTimeout(int shutdownTimeout) {
+		this.shutdownTimeout = shutdownTimeout;
+		return this;
+	}
+
 }


### PR DESCRIPTION
Introduced option to supply a main class and classpath instead of an executable jar. This is useful for situations such as testing where a boot app isn't in an executable jar.