### PR TITLE
Verify deployment state during deploy and undeploy exited instances

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -88,8 +88,10 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 	public String deploy(AppDeploymentRequest request) {
 		String group = request.getEnvironmentProperties().get(GROUP_PROPERTY_KEY);
 		String deploymentId = String.format("%s.%s", group, request.getDefinition().getName());
-		if (running.containsKey(deploymentId)) {
-			throw new IllegalStateException(String.format("App for '%s' is already running", deploymentId));
+		DeploymentState state = status(deploymentId).getState();
+		if (state != DeploymentState.unknown) {
+			throw new IllegalStateException(String.format("App %s is already deployed with state %s",
+					deploymentId, state));
 		}
 		List<AppInstance> processes = new ArrayList<>();
 		running.put(deploymentId, processes);
@@ -161,7 +163,12 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 				builder.with(instance);
 			}
 		}
-		return builder.build();
+		AppStatus status = builder.build();
+		// Make sure to explicitly undeploy any exited instances that have status undeployed.
+		if (status.getState().equals(DeploymentState.undeployed)) {
+			undeploy(id);
+		}
+		return status;
 	}
 
 	@PreDestroy


### PR DESCRIPTION
 - In local deployer the deployment status should be checked before deploying the app
  - This change removes the existing check to verify the running processes which could be wrong when the app exited but the map `running` still has references of exited instances

 - When checking the `status`, undeploy (cleanup the `running` map with exited instances) can be invoked

This resolves #71