### PR TITLE
Added default constructor.

### DIFF
--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -68,6 +68,13 @@ public class DelegatingResourceLoader implements ResourceLoader, ResourceLoaderA
 
 	/**
 	 * Instantiates a new delegating resource loader.
+	 */
+	public DelegatingResourceLoader() {
+		this(null, null);
+	}
+
+	/**
+	 * Instantiates a new delegating resource loader.
 	 *
 	 * @param loaders the loaders
 	 */


### PR DESCRIPTION
Since we now support "empty" or null loaders, a user should be able to use a default constructor.