### PR TITLE
Add TCK tests for tasks in abstract superclass

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
@@ -93,7 +93,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -127,7 +127,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -150,7 +150,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		log.info("Deploying {} again...", request.getDefinition().getName());
 
 		// Attempt re-deploy of SAME request
-		deploymentId = appDeployer().deploy(request);
+		deploymentId = record(appDeployer().deploy(request));
 		timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -178,7 +178,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deploying))), timeout.maxAttempts, timeout.pause));
@@ -202,7 +202,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(failed))), timeout.maxAttempts, timeout.pause));
@@ -232,7 +232,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -253,7 +253,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}, expecting it to fail...", request.getDefinition().getName());
 
-		deploymentId = appDeployer().deploy(request);
+		deploymentId = record(appDeployer().deploy(request));
 		timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(failed))), timeout.maxAttempts, timeout.pause));
@@ -282,7 +282,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -305,7 +305,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}, expecting it to fail...", request.getDefinition().getName());
 
-		deploymentId = appDeployer().deploy(request);
+		deploymentId = record(appDeployer().deploy(request));
 		timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(failed))), timeout.maxAttempts, timeout.pause));
@@ -337,7 +337,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Deploying {}...", request.getDefinition().getName());
 
-		String deploymentId = appDeployer().deploy(request);
+		String deploymentId = record(appDeployer().deploy(request));
 		Timeout timeout = deploymentTimeout();
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(partial))), timeout.maxAttempts, timeout.pause));

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationTests.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.deployer.spi.test;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Rule;
@@ -57,8 +59,22 @@ public abstract class AbstractIntegrationTests {
 	@Autowired(required = false)
 	protected MavenProperties mavenProperties;
 
+	// No duplicates, but keep insertion order
+	protected Set<String> deployments = new LinkedHashSet<>();
+
 	protected String randomName() {
 		return name.getMethodName() + "-" + UUID.randomUUID().toString();
+	}
+
+	/**
+	 * Record the fact that something was deployed, resulting in the given deployment id.
+	 * Useful for cleaning up resources in an implementation-specific way in subclasses.
+	 *
+	 * @return the deployment id, for chaining calls.
+	 */
+	protected String record(String deployment) {
+		deployments.add(deployment);
+		return deployment;
 	}
 
 	/**

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractTaskLauncherIntegrationTests.java
@@ -17,7 +17,14 @@
 package org.springframework.cloud.deployer.spi.test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.deployer.spi.task.LaunchState.complete;
+import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -25,9 +32,12 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import org.springframework.core.io.Resource;
 
 /**
  * Abstract base class for integration tests of
@@ -57,6 +67,114 @@ public abstract class AbstractTaskLauncherIntegrationTests extends AbstractInteg
 		assertThat(randomName(), hasStatusThat(
 				Matchers.<TaskStatus>hasProperty("state", is(LaunchState.unknown))));
 	}
+
+	@Test
+	public void testSimpleLaunch() throws InterruptedException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("killDelay", "0");
+		appProperties.put("exitCode", "0");
+		AppDefinition definition = new AppDefinition(randomName(), appProperties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Launching {}...", request.getDefinition().getName());
+		String launchId = record(taskLauncher().launch(request));
+
+		Timeout timeout = deploymentTimeout();
+		assertThat(launchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.complete))), timeout.maxAttempts, timeout.pause));
+
+	}
+
+	@Test
+	public void testReLaunch() throws InterruptedException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("killDelay", "0");
+		appProperties.put("exitCode", "0");
+		AppDefinition definition = new AppDefinition(randomName(), appProperties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Launching {}...", request.getDefinition().getName());
+		String launchId = record(taskLauncher().launch(request));
+
+		Timeout timeout = deploymentTimeout();
+		assertThat(launchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.complete))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Re-Launching {}...", request.getDefinition().getName());
+		String newLaunchId = record(taskLauncher().launch(request));
+
+		assertThat(newLaunchId, not(is(launchId)));
+
+		timeout = deploymentTimeout();
+		assertThat(newLaunchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.complete))), timeout.maxAttempts, timeout.pause));
+
+	}
+
+	@Test
+	public void testErrorExit() throws InterruptedException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("killDelay", "0");
+		appProperties.put("exitCode", "1");
+		AppDefinition definition = new AppDefinition(randomName(), appProperties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Launching {}...", request.getDefinition().getName());
+		String launchId = record(taskLauncher().launch(request));
+
+		Timeout timeout = deploymentTimeout();
+		assertThat(launchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.failed))), timeout.maxAttempts, timeout.pause));
+
+	}
+
+	@Test
+	public void testSimpleCancel() throws InterruptedException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("killDelay", "-1");
+		appProperties.put("exitCode", "0");
+		AppDefinition definition = new AppDefinition(randomName(), appProperties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Launching {}...", request.getDefinition().getName());
+		String launchId = record(taskLauncher().launch(request));
+
+		Timeout timeout = deploymentTimeout();
+		assertThat(launchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.running))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Cancelling {}...", request.getDefinition().getName());
+		taskLauncher().cancel(launchId);
+
+		timeout = undeploymentTimeout();
+		assertThat(launchId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.cancelled))), timeout.maxAttempts, timeout.pause));
+
+	}
+
+	/**
+	 * Tests that command line args can be passed in.
+	 */
+	@Test
+	public void testCommandLineArgs() {
+		Map<String, String> properties = new HashMap<>();
+		properties.put("killDelay", "1000");
+		AppDefinition definition = new AppDefinition(randomName(), properties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, Collections.<String, String>emptyMap(),
+				Collections.singletonList("--exitCode=0"));
+		log.info("Launching {}...", request.getDefinition().getName());
+		String deploymentId = record(taskLauncher().launch(request));
+
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<TaskStatus>hasProperty("state", Matchers.is(complete))), timeout.maxAttempts, timeout.pause));
+	}
+
 
 	/**
 	 * A Hamcrest Matcher that queries the deployment status for some task id.


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-deployer/issues/110

Fix LocalTaskLauncher to use a unique id for each launch
Record each deployment for subclasses to do their cleanup