### PR TITLE
Fix file name for non-File resources

### DIFF
--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -51,6 +51,7 @@ import org.springframework.util.FileCopyUtils;
  *
  * @author Mark Fisher
  * @author Janne Valkealahti
+ * @author Ilayaperumal Gopinathan
  */
 public class DelegatingResourceLoader implements ResourceLoader, ResourceLoaderAware {
 
@@ -117,7 +118,9 @@ public class DelegatingResourceLoader implements ResourceLoader, ResourceLoaderA
 				return resource;
 			}
 			else {
-				String cacheName = scheme + "-" + ShaUtils.sha1(location) + "-" + resource.getFilename();
+				String fileName = resource.getFilename();
+				fileName = (fileName != null) ? String.format("-%s", fileName.replaceAll("[^\\w\\-]","")) : "";
+				String cacheName = scheme + "-" + ShaUtils.sha1(location) + fileName;
 				File cachedResource = new File(cacheDirectory, cacheName);
 				if (!cachedResource.exists()) {
 					logger.info("Caching file {} as given location {}", cachedResource, location);

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -119,7 +119,7 @@ public class DelegatingResourceLoader implements ResourceLoader, ResourceLoaderA
 			}
 			else {
 				String fileName = resource.getFilename();
-				fileName = (fileName != null) ? String.format("-%s", fileName.replaceAll("[^\\w\\-]","")) : "";
+				fileName = (fileName != null) ? ShaUtils.sha1(fileName) : "";
 				String cacheName = scheme + "-" + ShaUtils.sha1(location) + fileName;
 				File cachedResource = new File(cacheDirectory, cacheName);
 				if (!cachedResource.exists()) {

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -18,8 +18,11 @@ package org.springframework.cloud.deployer.resource.support;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -32,6 +35,7 @@ import org.junit.rules.TemporaryFolder;
 import org.springframework.cloud.deployer.resource.StubResourceLoader;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
@@ -40,6 +44,7 @@ import org.springframework.core.io.ResourceLoader;
  *
  * @author Patrick Peralta
  * @author Janne Valkealahti
+ * @author Ilayaperumal Gopinathan
  */
 public class DelegatingResourceLoaderTests {
 
@@ -88,6 +93,69 @@ public class DelegatingResourceLoaderTests {
 		assertEquals(file.exists(), true);
 	}
 
+	@Test
+	public void testFileNameWithSpecialCharacters1() throws IOException {
+		String testContent = "testing foo bar";
+		String fileName = "r1///3abc";
+		CustomResource resource1 = new CustomResource(fileName, testContent);
+		Map<String, ResourceLoader> map = new HashMap<>();
+		map.put("s3", new StubResourceLoader(resource1));
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
+		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
+		assertTrue(cachedResource1.getFilename().endsWith("r13abc"));
+		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
+		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
+	}
+
+	@Test
+	public void testFileNameWithSpecialCharacters2() throws IOException {
+		String testContent = "testing foo bar";
+		String fileName = "r1///$#@3-abc";
+		CustomResource resource1 = new CustomResource(fileName, testContent);
+		Map<String, ResourceLoader> map = new HashMap<>();
+		map.put("s3", new StubResourceLoader(resource1));
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
+		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
+		assertTrue(cachedResource1.getFilename().endsWith("r13-abc"));
+		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
+		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
+	}
+
+	@Test
+	public void testFileNameWithSpecialCharacters3() throws IOException {
+		String testContent = "testing foo bar";
+		String fileName = "r1--3_abc$";
+		CustomResource resource1 = new CustomResource(fileName, testContent);
+		Map<String, ResourceLoader> map = new HashMap<>();
+		map.put("s3", new StubResourceLoader(resource1));
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
+		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
+		assertTrue(cachedResource1.getFilename().endsWith("r1--3_abc"));
+		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
+		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
+	}
+
+	@Test
+	public void testCacheWithSpecialCharactersInFileName() throws IOException {
+		String testContent = "testing foo bar";
+		String fileName = "r1///3abc#123";
+		CustomResource resource1 = new CustomResource(fileName, testContent);
+		Map<String, ResourceLoader> map = new HashMap<>();
+		map.put("s3", new StubResourceLoader(resource1));
+		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
+		FileSystemResource cachedResource1 = (FileSystemResource) resourceLoader.getResource("s3://"+ fileName);
+		assertTrue(cachedResource1.getFilename().endsWith("r13abc123"));
+		StringBuilder builder = new StringBuilder();
+		int ch;
+		FileInputStream fileInputStream = (FileInputStream) cachedResource1.getInputStream();
+		while ((ch = fileInputStream.read()) != -1) {
+			builder.append((char)ch);
+		}
+		assertEquals(testContent, builder.toString());
+		FileSystemResource cachedResource2 = (FileSystemResource) resourceLoader.getResource("s3://"+ fileName);
+		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
+	}
+
 	static class NullResource extends AbstractResource {
 
 		final String description;
@@ -109,6 +177,38 @@ public class DelegatingResourceLoaderTests {
 		@Override
 		public InputStream getInputStream() throws IOException {
 			return null;
+		}
+	}
+
+	static class CustomResource extends AbstractResource {
+
+		final String name;
+
+		final String content;
+
+		public CustomResource(String name, String content) {
+			this.name = name;
+			this.content = content;
+		}
+
+		@Override
+		public String getDescription() {
+			return name;
+		}
+
+		@Override
+		public File getFile() throws IOException {
+			throw new IOException();
+		}
+
+		@Override
+		public String getFilename() {
+			return name;
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return new ByteArrayInputStream(this.content.getBytes());
 		}
 	}
 

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -102,7 +102,6 @@ public class DelegatingResourceLoaderTests {
 		map.put("s3", new StubResourceLoader(resource1));
 		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
 		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		assertTrue(cachedResource1.getFilename().endsWith("r13abc"));
 		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
 		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
 	}
@@ -116,7 +115,6 @@ public class DelegatingResourceLoaderTests {
 		map.put("s3", new StubResourceLoader(resource1));
 		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
 		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		assertTrue(cachedResource1.getFilename().endsWith("r13-abc"));
 		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
 		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
 	}
@@ -130,7 +128,6 @@ public class DelegatingResourceLoaderTests {
 		map.put("s3", new StubResourceLoader(resource1));
 		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
 		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		assertTrue(cachedResource1.getFilename().endsWith("r1--3_abc"));
 		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
 		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
 	}
@@ -144,7 +141,6 @@ public class DelegatingResourceLoaderTests {
 		map.put("s3", new StubResourceLoader(resource1));
 		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
 		FileSystemResource cachedResource1 = (FileSystemResource) resourceLoader.getResource("s3://"+ fileName);
-		assertTrue(cachedResource1.getFilename().endsWith("r13abc123"));
 		StringBuilder builder = new StringBuilder();
 		int ch;
 		FileInputStream fileInputStream = (FileInputStream) cachedResource1.getInputStream();


### PR DESCRIPTION
  - If the resource loader gets the resource whose filename doesn't exactly return the last part of the filepath and also if the filename happens to have special characters for some reason, then the cache filename for that resource will remove the invalid/not supported characters
  - Only word characters, numbers, _ and - are allowed
  - Add tests

Fixes #96