### PR TITLE
GH-116 Fix usage of javaOpts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 		<spring-framework.version>4.3.3.RELEASE</spring-framework.version>
 		<spring-cloud.version>Camden.RELEASE</spring-cloud.version>
 		<aether.version>1.0.2.v20150114</aether.version>

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperties.LOCAL_PROPERTIES;
+
+/**
+ * A class to help create the execution command for launching a Java Process.
+ *
+ * @author Mark Pollack
+ */
+public class ExecutionCommandBuilder {
+
+    private static final String MAIN =  "main";
+
+    private static final String CLASSPATH = "classpath";
+
+    public void addJavaOptions(List<String> commands, Map<String, String> deploymentProperties,
+                               LocalDeployerProperties localDeployerProperties) {
+        String memory = null;
+        if (containsKey(deploymentProperties, "memory")) {
+            memory = "-Xmx" + getValue(deploymentProperties, "memory");
+        }
+
+        String javaOptsString = getValue(deploymentProperties, "javaOpts");
+        if (javaOptsString == null && memory != null) {
+            commands.add(memory);
+        }
+
+        if (javaOptsString != null) {
+            String[] javaOpts = StringUtils.tokenizeToStringArray(javaOptsString, " ");
+            boolean noJavaMemoryOption = !Stream.of(javaOpts).anyMatch(s -> s.startsWith("-Xmx"));
+            if (noJavaMemoryOption && memory != null) {
+                commands.add(memory);
+            }
+            commands.addAll(Arrays.asList(javaOpts));
+        } else {
+            if (localDeployerProperties.getJavaOpts() != null) {
+                String[] javaOpts = StringUtils.tokenizeToStringArray(localDeployerProperties.getJavaOpts(), " ");
+                commands.addAll(Arrays.asList(javaOpts));
+            }
+        }
+    }
+
+    public void addJavaExecutionOptions(List<String> commands, AppDeploymentRequest request) {
+        Map<String, String> deploymentProperties = request.getDeploymentProperties();
+        if (containsKey(deploymentProperties, MAIN) || containsKey(deploymentProperties, CLASSPATH)) {
+            Assert.isTrue(containsKey(deploymentProperties, MAIN)
+                            && containsKey(deploymentProperties, CLASSPATH),
+                    LOCAL_PROPERTIES + "." + MAIN + " and " + LOCAL_PROPERTIES + "." + CLASSPATH +
+                            " deployment properties are both required if either is provided.");
+            commands.add("-cp");
+            commands.add(getValue(deploymentProperties, CLASSPATH));
+            commands.add(getValue(deploymentProperties, MAIN));
+        }
+        else {
+            commands.add("-jar");
+            Resource resource = request.getResource();
+            try {
+                commands.add(resource.getFile().getAbsolutePath());
+            }
+            catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private boolean containsKey(Map<String, String> deploymentProperties, String propertyName) {
+        return deploymentProperties.containsKey(LOCAL_PROPERTIES + "." + propertyName);
+    }
+
+    private String getValue(Map<String, String> deploymentProperties, String propertyName) {
+        return deploymentProperties.get(LOCAL_PROPERTIES + "." + propertyName);
+    }
+}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -28,8 +28,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
  */
-@ConfigurationProperties(prefix = "deployer.local")
+@ConfigurationProperties(prefix = LocalDeployerProperties.LOCAL_PROPERTIES)
 public class LocalDeployerProperties {
+
+	/**
+	 * Top level prefix for local deployer configuration properties.
+	 */
+	public static final String LOCAL_PROPERTIES = "spring.cloud.deployer.local";
 
 	/**
 	 * Directory in which all created processes will run and create log files.
@@ -57,6 +62,11 @@ public class LocalDeployerProperties {
 	 * via the {@code /shutdown} endpoint.
 	 */
 	private int shutdownTimeout = 30;
+
+	/**
+	 * The Java Options to pass to the JVM, e.g -Dtest=foo
+	 */
+	private String javaOpts;
 
 
 	public String getJavaCmd() {
@@ -98,6 +108,14 @@ public class LocalDeployerProperties {
 	public LocalDeployerProperties setShutdownTimeout(int shutdownTimeout) {
 		this.shutdownTimeout = shutdownTimeout;
 		return this;
+	}
+
+	public String getJavaOpts() {
+		return javaOpts;
+	}
+
+	public void setJavaOpts(String javaOpts) {
+		this.javaOpts = javaOpts;
 	}
 
 }

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilderTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.deployer.resource.maven.MavenResource;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.test.app.DeployerIntegrationTestProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperties.LOCAL_PROPERTIES;
+
+public class ExecutionCommandBuilderTests {
+
+    private ExecutionCommandBuilder commandBuilder;
+    private List<String> args;
+    private Map<String, String> deploymentProperties;
+    private LocalDeployerProperties localDeployerProperties;
+
+    @Before
+    public void setUp() {
+        commandBuilder = new ExecutionCommandBuilder();
+        args = new ArrayList<>();
+        deploymentProperties = new HashMap<>();
+        localDeployerProperties = new LocalDeployerProperties();
+
+    }
+
+    @Test
+    public void testExecutionOptions() {
+
+    }
+
+    @Test
+    public void testDirectJavaMemoryOption() {
+        deploymentProperties.put(LOCAL_PROPERTIES + ".memory", "1024m");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(1));
+        assertThat(args.get(0), is("-Xmx1024m"));
+    }
+
+    @Test
+    public void testJavaMemoryOption() {
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Xmx1024m");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(1));
+        assertThat(args.get(0), is("-Xmx1024m"));
+    }
+
+    @Test
+    public void testOverrideMemoryOptions() {
+        deploymentProperties.put(LOCAL_PROPERTIES + ".memory", "1024m");
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Xmx2048m");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(1));
+        assertThat(args.get(0), is("-Xmx2048m"));
+    }
+
+    @Test
+    public void testDirectMemoryOptionsWithOtherOptions() {
+        deploymentProperties.put(LOCAL_PROPERTIES + ".memory", "1024m");
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Dtest=foo");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(2));
+        assertThat(args.get(0), is("-Xmx1024m"));
+        assertThat(args.get(1), is("-Dtest=foo"));
+    }
+
+    @Test
+    public void testMultipleOptions() {
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Dtest=foo -Dbar=baz");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(2));
+        assertThat(args.get(0), is("-Dtest=foo"));
+        assertThat(args.get(1), is("-Dbar=baz"));
+    }
+
+    @Test
+    public void testConfigurationPropertiesOverride() {
+        localDeployerProperties.setJavaOpts("-Dfoo=test -Dbaz=bar");
+        commandBuilder.addJavaOptions(args, deploymentProperties, localDeployerProperties);
+        assertThat(args.size(), is(2));
+        assertThat(args.get(0), is("-Dfoo=test"));
+        assertThat(args.get(1), is("-Dbaz=bar"));
+    }
+
+
+    @Test
+    public void testJarExecution() throws MalformedURLException {
+        AppDefinition definition = new AppDefinition("randomApp", new HashMap<>());
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Dtest=foo -Dbar=baz");
+        AppDeploymentRequest appDeploymentRequest =
+                new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+        commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
+        assertThat(args.size(), is(2));
+        assertThat(args.get(0), is("-jar"));
+        assertThat(args.get(1), containsString("testResource.txt"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testBadResourceExecution() throws MalformedURLException {
+        AppDefinition definition = new AppDefinition("randomApp", new HashMap<>());
+        deploymentProperties.put(LOCAL_PROPERTIES + ".javaOpts", "-Dtest=foo -Dbar=baz");
+        AppDeploymentRequest appDeploymentRequest =
+                new AppDeploymentRequest(definition, new UrlResource("http://spring.io"), deploymentProperties);
+        commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
+    }
+
+    @Test
+    public void testMainExecution() throws MalformedURLException {
+        String mainApp = "org.foo.Main";
+        String mainJar = "/tmp/myapp.jar";
+        AppDefinition definition = new AppDefinition("randomApp", new HashMap<>());
+        deploymentProperties.put(LOCAL_PROPERTIES + ".main", mainApp);
+        deploymentProperties.put(LOCAL_PROPERTIES + ".classpath", mainJar);
+        AppDeploymentRequest appDeploymentRequest =
+                new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+        commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
+        assertThat(args.size(), is(3));
+        assertThat(args.get(0), is("-cp"));
+        assertThat(args.get(1), is(mainJar));
+        assertThat(args.get(2), is(mainApp));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingMain() throws MalformedURLException {
+        String mainJar = "/tmp/myapp.jar";
+        AppDefinition definition = new AppDefinition("randomApp", new HashMap<>());
+        deploymentProperties.put(LOCAL_PROPERTIES + ".classpath", mainJar);
+        AppDeploymentRequest appDeploymentRequest =
+                new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+        commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
+    }
+
+
+
+    protected Resource testResource() throws MalformedURLException {
+        return new ClassPathResource("testResource.txt");
+    }
+
+}


### PR DESCRIPTION
- Change LocalDeployerProperties prefix to spring.cloud.deployer.local
- Add javaOpts property to LocalDeployerProperties, used if no javaOpt
  deployment properties were set in the ApplicationDeploymentRequest
- Support setting the -Xmx Java options using
  spring.cloud.deployer.local.memory in deployment properties of
  ApplicationDeploymentRequest
- Support setting Java Options using
  spring.cloud.deployer.local.javaOpts in deployment properties of
  ApplicationDeploymentRequest
- Switch to use Java 1.8
- Fixed usage of spring.cloud.deployer.local.main and
  spring.cloud.deployer.local.classpath
- Added tests

Resolves spring-cloud/spring-cloud-deployer#116