### PR TITLE
Add deployer name suffix constant to interface

### DIFF
--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -32,6 +32,8 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
  */
 public interface AppDeployer {
 
+	static final String APP_DEPLOYER_NAME_SUFFIX = "AppDeployer";
+
 	/**
 	 * Common prefix used for deployment properties.
 	 */

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
@@ -37,6 +37,8 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
  */
 public interface TaskLauncher {
 
+	static final String TASK_LAUNCHER_NAME_SUFFIX = "TaskDeployer";
+
 	/**
 	 * Launch a task for the provided {@link AppDeploymentRequest}. The returned
 	 * id may later be used with {@link #cancel(String)} or


### PR DESCRIPTION
 - These suffix constants can be used to assign bean names across deployer implementations

Resolves #130