### PR TITLE
Throw IllegalStateException during undeploy usecase

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,12 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		appDeployer().undeploy(deploymentId);
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+		try {
+			appDeployer().undeploy(deploymentId);
+			fail("Should have thrown an IllegalStateException");
+		}
+		catch (IllegalStateException ok) {
+		}
 	}
 
 	/**


### PR DESCRIPTION
- When the app has not been deployed, the undeploy invocation should throw `IllegalStateException`.
 - Update the test case in `AbstractAppDeployerIntegrationTests` to have all the deployer implementations to conform

Resolves #185