### PR TITLE
Add explicit Http resource loader

### DIFF
--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoader.java
@@ -110,31 +110,14 @@ public class DelegatingResourceLoader implements ResourceLoader, ResourceLoaderA
 			Assert.notNull(scheme, "a scheme (prefix) is required");
 			ResourceLoader loader = this.loaders.get(scheme);
 			if (loader == null) {
-				loader = this.defaultResourceLoader;
-			}
-			Resource resource = loader.getResource(location);
-			if (existsAsFile(resource)) {
-				return resource;
-			}
-			else {
-				String cacheName = scheme + "-" + ShaUtils.sha1(location);
-				File cachedResource = new File(cacheDirectory, cacheName);
-				if (!cachedResource.exists()) {
-					logger.info("Caching resource '{}' as file {}", location, cachedResource);
-					try {
-						FileCopyUtils.copy(resource.getInputStream(), new FileOutputStream(cachedResource));
-					}
-					catch (UnsupportedOperationException e) {
-						logger.warn(String.format("Unable to cache file since getInputStream() is "
-								+ "not supported for resource: %s", resource));
-						return resource;
-					}
+				if (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")) {
+					loader = new HttpResourceLoader();
 				}
 				else {
-					logger.info("Reusing cached file {} as given location '{}'", cachedResource, location);
+					loader = this.defaultResourceLoader;
 				}
-				return new FileSystemResource(cachedResource);
 			}
+			return loader.getResource(location);
 		}
 		catch (Exception e) {
 			throw new ResourceNotResolvedException(e.getMessage(), e);

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResource.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResource.java
@@ -37,22 +37,24 @@ import org.springframework.util.FileCopyUtils;
  */
 public class HttpResource extends UrlResource {
 
-	private final String location;
-
 	public HttpResource(String location) throws MalformedURLException {
 		super(location);
-		this.location = location;
 	}
 
 	@Override
 	public String getDescription() {
-		return "Http Resource [" + location + "]";
+		try {
+			return "Http Resource [" + this.getURL().getPath() + "]";
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override
 	public File getFile() throws IOException {
-		String fileName = ShaUtils.sha1(location);
-		File tempFile = new File(Files.createTempDirectory("").toFile(), fileName);
+		String fileName = ShaUtils.sha1(this.getURL().getPath());
+		File tempFile = new File(Files.createTempDirectory("spring-cloud-deployer").toFile(), fileName);
 		FileCopyUtils.copy(this.getInputStream(), new FileOutputStream(tempFile));
 		tempFile.deleteOnExit();
 		return tempFile;

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResource.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.resource.support;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.file.Files;
+
+import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.util.Assert;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * A {@link Resource} implementation for resolving HTTP resource.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class HttpResource extends UrlResource {
+
+	private final String location;
+
+	public HttpResource(String location) throws MalformedURLException {
+		super(location);
+		this.location = location;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Http Resource [" + location + "]";
+	}
+
+	@Override
+	public File getFile() throws IOException {
+		String fileName = ShaUtils.sha1(location);
+		File tempFile = new File(Files.createTempDirectory("").toFile(), fileName);
+		FileCopyUtils.copy(this.getInputStream(), new FileOutputStream(tempFile));
+		tempFile.deleteOnExit();
+		return tempFile;
+	}
+
+}

--- a/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResourceLoader.java
+++ b/spring-cloud-deployer-resource-support/src/main/java/org/springframework/cloud/deployer/resource/support/HttpResourceLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.resource.support;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * Resource loader for HTTP/HTTPS schemes that doesn't cache resources.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class HttpResourceLoader extends DefaultResourceLoader {
+
+	@Override
+	public Resource getResource(String location) {
+		try {
+			return new HttpResource(location);
+		}
+		catch (MalformedURLException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -16,13 +16,7 @@
 
 package org.springframework.cloud.deployer.resource.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -34,10 +28,10 @@ import org.junit.rules.TemporaryFolder;
 
 import org.springframework.cloud.deployer.resource.StubResourceLoader;
 import org.springframework.core.io.AbstractResource;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Tests for {@link DelegatingResourceLoader}.
@@ -47,8 +41,6 @@ import org.springframework.core.io.ResourceLoader;
  * @author Ilayaperumal Gopinathan
  */
 public class DelegatingResourceLoaderTests {
-
-	private final static String HTTP_RESOURCE = "http://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom";
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
@@ -73,85 +65,6 @@ public class DelegatingResourceLoaderTests {
 		assertEquals(three, resourceLoader.getResource("three://three"));
 	}
 
-	@Test
-	public void testDefaultCache() throws IOException {
-		Map<String, ResourceLoader> loaders = new HashMap<>();
-		loaders.put("http", new DefaultResourceLoader());
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(loaders);
-		Resource resource = resourceLoader.getResource(HTTP_RESOURCE);
-		File file = resource.getFile();
-		assertEquals(file.exists(), true);
-	}
-
-	@Test
-	public void testManualCache() throws IOException {
-		Map<String, ResourceLoader> loaders = new HashMap<>();
-		loaders.put("http", new DefaultResourceLoader());
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(loaders, folder.getRoot());
-		Resource resource = resourceLoader.getResource(HTTP_RESOURCE);
-		File file = resource.getFile();
-		assertEquals(file.exists(), true);
-	}
-
-	@Test
-	public void testFileNameWithSpecialCharacters1() throws IOException {
-		String testContent = "testing foo bar";
-		String fileName = "r1///3abc";
-		CustomResource resource1 = new CustomResource(fileName, testContent);
-		Map<String, ResourceLoader> map = new HashMap<>();
-		map.put("s3", new StubResourceLoader(resource1));
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
-		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
-		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
-	}
-
-	@Test
-	public void testFileNameWithSpecialCharacters2() throws IOException {
-		String testContent = "testing foo bar";
-		String fileName = "r1///$#@3-abc";
-		CustomResource resource1 = new CustomResource(fileName, testContent);
-		Map<String, ResourceLoader> map = new HashMap<>();
-		map.put("s3", new StubResourceLoader(resource1));
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
-		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
-		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
-	}
-
-	@Test
-	public void testFileNameWithSpecialCharacters3() throws IOException {
-		String testContent = "testing foo bar";
-		String fileName = "r1--3_abc$";
-		CustomResource resource1 = new CustomResource(fileName, testContent);
-		Map<String, ResourceLoader> map = new HashMap<>();
-		map.put("s3", new StubResourceLoader(resource1));
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
-		Resource cachedResource1 = resourceLoader.getResource("s3://" + fileName);
-		Resource cachedResource2 = resourceLoader.getResource("s3://"+ fileName);
-		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
-	}
-
-	@Test
-	public void testCacheWithSpecialCharactersInFileName() throws IOException {
-		String testContent = "testing foo bar";
-		String fileName = "r1///3abc#123";
-		CustomResource resource1 = new CustomResource(fileName, testContent);
-		Map<String, ResourceLoader> map = new HashMap<>();
-		map.put("s3", new StubResourceLoader(resource1));
-		DelegatingResourceLoader resourceLoader = new DelegatingResourceLoader(map);
-		FileSystemResource cachedResource1 = (FileSystemResource) resourceLoader.getResource("s3://"+ fileName);
-		StringBuilder builder = new StringBuilder();
-		int ch;
-		FileInputStream fileInputStream = (FileInputStream) cachedResource1.getInputStream();
-		while ((ch = fileInputStream.read()) != -1) {
-			builder.append((char)ch);
-		}
-		assertEquals(testContent, builder.toString());
-		FileSystemResource cachedResource2 = (FileSystemResource) resourceLoader.getResource("s3://"+ fileName);
-		assertEquals(cachedResource1.getFile(), cachedResource2.getFile());
-	}
-
 	static class NullResource extends AbstractResource {
 
 		final String description;
@@ -173,38 +86,6 @@ public class DelegatingResourceLoaderTests {
 		@Override
 		public InputStream getInputStream() throws IOException {
 			return null;
-		}
-	}
-
-	static class CustomResource extends AbstractResource {
-
-		final String name;
-
-		final String content;
-
-		public CustomResource(String name, String content) {
-			this.name = name;
-			this.content = content;
-		}
-
-		@Override
-		public String getDescription() {
-			return name;
-		}
-
-		@Override
-		public File getFile() throws IOException {
-			throw new IOException();
-		}
-
-		@Override
-		public String getFilename() {
-			return name;
-		}
-
-		@Override
-		public InputStream getInputStream() throws IOException {
-			return new ByteArrayInputStream(this.content.getBytes());
 		}
 	}
 

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/HttpResourceTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/HttpResourceTests.java
@@ -13,27 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.deployer.resource.support;
 
-import java.net.MalformedURLException;
+import java.io.File;
 
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.Resource;
+import org.junit.Test;
+
+import org.springframework.util.Assert;
 
 /**
- * Resource loader for HTTP/HTTPS schemes that doesn't cache resources.
- *
  * @author Ilayaperumal Gopinathan
  */
-public class HttpResourceLoader extends DefaultResourceLoader {
+public class HttpResourceTests {
 
-	@Override
-	public Resource getResource(String location) {
-		try {
-			return new HttpResource(location);
-		}
-		catch (MalformedURLException e) {
-			throw new IllegalStateException(e);
-		}
+	@Test
+	public void testHttpResourceGetFile() throws Exception {
+		String location = "https://github.com/spring-cloud/spring-cloud-deployer/blob/master/pom.xml";
+		HttpResource httpResource = new HttpResource(location);
+		File file1 = httpResource.getFile();
+		File file2 = httpResource.getFile();
+		Assert.isTrue(!file1.getPath().equals(file2.getPath()), "Files should be different");
 	}
 }


### PR DESCRIPTION
 - This will make sure to use HttpResource
 - Add HttpResourceLoader that downloads the URLResource instead of expecting it to be on the File system
 - Add this to delegating resource loader when using schemes `http` and `https`

Resolves #238
Resolves #237