### PR TITLE
Add global update/checksum policy

### DIFF
--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolver.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolver.java
@@ -228,6 +228,8 @@ class MavenArtifactResolver {
 		LocalRepository localRepo = new LocalRepository(localRepoPath);
 		session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
 		session.setOffline(this.properties.isOffline());
+		session.setUpdatePolicy(this.properties.getUpdatePolicy());
+		session.setChecksumPolicy(this.properties.getChecksumPolicy());
 		if (this.properties.getConnectTimeout() != null) {
 			session.setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, this.properties.getConnectTimeout());
 		}

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
@@ -74,6 +74,26 @@ public class MavenProperties {
 	 */
 	private boolean resolvePom;
 
+	public String updatePolicy;
+
+	public String checksumPolicy;
+
+	public String getUpdatePolicy() {
+		return updatePolicy;
+	}
+
+	public void setUpdatePolicy(String updatePolicy) {
+		this.updatePolicy = updatePolicy;
+	}
+
+	public String getChecksumPolicy() {
+		return checksumPolicy;
+	}
+
+	public void setChecksumPolicy(String checksumPolicy) {
+		this.checksumPolicy = checksumPolicy;
+	}
+
 	public Map<String, RemoteRepository> getRemoteRepositories() {
 		return remoteRepositories;
 	}
@@ -261,40 +281,40 @@ public class MavenProperties {
 		public void setReleasePolicy(RepositoryPolicy releasePolicy) {
 			this.releasePolicy = releasePolicy;
 		}
+	}
 
-		public static class RepositoryPolicy {
+	public static class RepositoryPolicy {
 
-			private boolean enabled = true;
+		private boolean enabled = true;
 
-			private String updatePolicy = "always";
+		private String updatePolicy = "always";
 
-			private String checksumPolicy = "warn";
+		private String checksumPolicy = "warn";
 
-			public boolean isEnabled() {
-				return enabled;
-			}
-
-			public void setEnabled(boolean enabled) {
-				this.enabled = enabled;
-			}
-
-			public String getUpdatePolicy() {
-				return updatePolicy;
-			}
-
-			public void setUpdatePolicy(String updatePolicy) {
-				this.updatePolicy = updatePolicy;
-			}
-
-			public String getChecksumPolicy() {
-				return checksumPolicy;
-			}
-
-			public void setChecksumPolicy(String checksumPolicy) {
-				this.checksumPolicy = checksumPolicy;
-			}
-
+		public boolean isEnabled() {
+			return enabled;
 		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getUpdatePolicy() {
+			return updatePolicy;
+		}
+
+		public void setUpdatePolicy(String updatePolicy) {
+			this.updatePolicy = updatePolicy;
+		}
+
+		public String getChecksumPolicy() {
+			return checksumPolicy;
+		}
+
+		public void setChecksumPolicy(String checksumPolicy) {
+			this.checksumPolicy = checksumPolicy;
+		}
+
 	}
 
 	public static class Authentication {


### PR DESCRIPTION
 - Add update/checksum policies as global level maven properties
 - These properties would be set at the RepositorySystemSession configuration
 - The remote repositories would still have their own RepositoryPolicy override options

Resolves #252