### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-== Spring Cloud Deployer image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-DEPMASTER[Build Status, link=https://build.spring.io/browse/SCD-DEPMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-deployer.svg?label=ready&title=Ready[Stories Ready, link=http://waffle.io/spring-cloud/spring-cloud-deployer] image:https://badge.waffle.io/spring-cloud/spring-cloud-deployer.svg?label=In%20Progress&title=In%20Progress[Stories In Progress, link=http://waffle.io/spring-cloud/spring-cloud-deployer]
+== Spring Cloud Deployer image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-DEPMASTER[Build Status, link=https://build.spring.io/browse/SCD-DEPMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-deployer.svg?label=ready&title=Ready[Stories Ready, link=https://waffle.io/spring-cloud/spring-cloud-deployer] image:https://badge.waffle.io/spring-cloud/spring-cloud-deployer.svg?label=In%20Progress&title=In%20Progress[Stories In Progress, link=https://waffle.io/spring-cloud/spring-cloud-deployer]
 
 The Spring Cloud Deployer project defines an SPI for deploying long lived applications and short lived tasks.
 

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolver.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolver.java
@@ -58,7 +58,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * Resolves a {@link MavenResource} using <a href="http://www.eclipse.org/aether/>aether</a> to
+ * Resolves a {@link MavenResource} using <a href="https://www.eclipse.org/aether/>aether</a> to
  * locate the artifact (uber jar) in a local Maven repository, downloading the latest update from a
  * remote repository if necessary.
  *

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
@@ -198,7 +198,7 @@ public class MavenProperties {
 	public static class RemoteRepository {
 
 		/**
-		 * URL of the remote maven repository. E.g. http://my.repo.com
+		 * URL of the remote maven repository. E.g. https://my.repo.com
 		 */
 		private String url;
 

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenResource.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenResource.java
@@ -221,7 +221,7 @@ public class MavenResource extends AbstractResource {
 	/**
 	 * Returns the coordinates encoded as
 	 * &lt;groupId&gt;:&lt;artifactId&gt;[:&lt;extension&gt;[:&lt;classifier&gt;]]:&lt;version&gt;,
-	 * conforming to the <a href="http://www.eclipse.org/aether">Aether</a> convention.
+	 * conforming to the <a href="https://www.eclipse.org/aether">Aether</a> convention.
 	 */
 	@Override
 	public String toString() {
@@ -239,7 +239,7 @@ public class MavenResource extends AbstractResource {
 	 * Create a {@link MavenResource} for the provided coordinates and default properties.
 	 *
 	 * @param coordinates coordinates encoded as &lt;groupId&gt;:&lt;artifactId&gt;[:&lt;extension&gt;[:&lt;classifier&gt;]]:&lt;version&gt;,
-	 * conforming to the <a href="http://www.eclipse.org/aether">Aether</a> convention.
+	 * conforming to the <a href="https://www.eclipse.org/aether">Aether</a> convention.
 	 * @return the {@link MavenResource}
 	 */
 	public static MavenResource parse(String coordinates) {
@@ -250,7 +250,7 @@ public class MavenResource extends AbstractResource {
 	 * Create a {@link MavenResource} for the provided coordinates and properties.
 	 *
 	 * @param coordinates coordinates encoded as &lt;groupId&gt;:&lt;artifactId&gt;[:&lt;extension&gt;[:&lt;classifier&gt;]]:&lt;version&gt;,
-	 * conforming to the <a href="http://www.eclipse.org/aether">Aether</a> convention.
+	 * conforming to the <a href="https://www.eclipse.org/aether">Aether</a> convention.
 	 * @param properties the properties for the repositories, proxies, and authentication
 	 * @return the {@link MavenResource}
 	 */

--- a/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
+++ b/spring-cloud-deployer-resource-support/src/test/java/org/springframework/cloud/deployer/resource/support/DelegatingResourceLoaderTests.java
@@ -49,7 +49,7 @@ import org.springframework.core.io.ResourceLoader;
  */
 public class DelegatingResourceLoaderTests {
 
-	private final static String HTTP_RESOURCE = "http://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom";
+	private final static String HTTP_RESOURCE = "https://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom";
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom ([https](https://repo.spring.io/libs-release-local/org/springframework/spring-core/4.2.5.RELEASE/spring-core-4.2.5.RELEASE.pom) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-deployer with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-deployer ([https](https://waffle.io/spring-cloud/spring-cloud-deployer) result 200).
* [ ] http://my.repo.com with 1 occurrences migrated to:  
  https://my.repo.com ([https](https://my.repo.com) result 302).
* [ ] http://www.eclipse.org/aether with 3 occurrences migrated to:  
  https://www.eclipse.org/aether ([https](https://www.eclipse.org/aether) result 302).
* [ ] http://www.eclipse.org/aether/ with 1 occurrences migrated to:  
  https://www.eclipse.org/aether/ ([https](https://www.eclipse.org/aether/) result 302).