### PR TITLE
Add aspect to log MavenArtifactResolver.resolve()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<java.version>1.8</java.version>
 		<aether.version>1.0.2.v20150114</aether.version>
 		<maven.version>3.2.1</maven.version>
+		<aspectj.version>1.9.2</aspectj.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -50,10 +50,48 @@
 			<version>${maven.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjrt</artifactId>
+			<version>${aspectj.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>aspectj-maven-plugin</artifactId>
+				<version>1.11</version>
+				<configuration>
+					<complianceLevel>${java.version}</complianceLevel>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<showWeaveInfo>true</showWeaveInfo>
+					<verbose>true</verbose>
+					<Xlint>ignore</Xlint>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.aspectj</groupId>
+						<artifactId>aspectjtools</artifactId>
+						<version>${aspectj.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverAspect.aj
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverAspect.aj
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.resource.maven;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AspectJ advice that logs the first time the {@link MavenArtifactResolver} <pre>resolve()</pre> method is invoked
+ * by a {@link MavenResource} by instances with the same fileName. This avoids duplicate log messages since
+ * <pre>MavenResource</pre> is not a singleton and each instance invokes <pre></pre>MavenArtifactResolver.resolve()</pre>
+ * multiple times in its lifecycle.
+ *
+ * @author David Turanski
+ **/
+aspect MavenArtifactResolverAspect {
+
+	private final Set<String> resolvedResources = new TreeSet();
+
+	private static Logger logger = LoggerFactory.getLogger(MavenArtifactResolver.class);
+
+	@Before(
+		"execution( * org.springframework.cloud.deployer.resource.maven.MavenArtifactResolver.resolve(..))")
+	public void trackResolvedResource(JoinPoint joinPoint) {
+		MavenResource resource = (MavenResource) joinPoint.getArgs()[0];
+		if (!resolvedResources.contains(resource.getFilename())) {
+			logger.info("Resolving Maven resource {}. This may take some time if the artifact must be downloaded "
+				+ "from a remote Maven repository.", resource.getFilename());
+			resolvedResources.add(resource.getFilename());
+		}
+	}
+}
+


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-dataflow/issues/2909

Uses AspectJ to log messages for invocations of `MavenArtifactResolver.resolve()`. Since this is not a Spring bean, Spring AOP doesn't apply. Artifact paths are cached to avoid lots of duplicate log messages. 
