### PR TITLE
Add getLog SPI to AppDeployer/TaskLauncher

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
@@ -488,6 +488,11 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 			return wrapped.environmentInfo();
 		}
 
+		@Override
+		public String getLog(String id) {
+			return wrapped.getLog(id);
+		}
+
 	}
 
 

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractTaskLauncherIntegrationTests.java
@@ -328,6 +328,11 @@ public abstract class AbstractTaskLauncherIntegrationTests extends AbstractInteg
 			return wrapped.getRunningTaskExecutionCount();
 		}
 
+		@Override
+		public String getLog(String id) {
+			return wrapped.getLog(id);
+		}
+
 	}
 
 

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
  * @author Marius Bogoevici
  * @author Janne Valkealahti
  * @author Thomas Risberg
+ * @author Ilayaperumal Gopinathan
  */
 public interface AppDeployer {
 
@@ -143,4 +144,11 @@ public interface AppDeployer {
 	 * @return the runtime environment info
 	 */
 	RuntimeEnvironmentInfo environmentInfo();
+
+	/**
+	 * Return the log of the application identified by the deployment id.
+	 *
+	 * @return the application log
+	 */
+	String getLog(String id);
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
  * @author Mark Fisher
  * @author Janne Valkealahti
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  */
 public interface TaskLauncher {
 
@@ -121,4 +122,12 @@ public interface TaskLauncher {
 	default int getRunningTaskExecutionCount() {
 		throw new UnsupportedOperationException("'getRunningTaskExecutionCount' is not implemented.");
 	}
+
+	/**
+	 * Return the log of the application identified by the task ID.
+	 * The ID can be specific to the platform where the task is launched.
+	 *
+	 * @return the task application log
+	 */
+	String getLog(String id);
 }


### PR DESCRIPTION
 - This SPI method lets the AppDeployer/TaskLauncher implementations to retrieve application logs based on the platform

Resolves #306