### PR TITLE
Add default method for getLog

### DIFF
--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -150,5 +150,7 @@ public interface AppDeployer {
 	 *
 	 * @return the application log
 	 */
-	String getLog(String id);
+	default String getLog(String id) {
+		throw new UnsupportedOperationException("'getLog' is not implemented.");
+	}
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/task/TaskLauncher.java
@@ -129,5 +129,7 @@ public interface TaskLauncher {
 	 *
 	 * @return the task application log
 	 */
-	String getLog(String id);
+	default String getLog(String id) {
+		throw new UnsupportedOperationException("'getLog' is not implemented.");
+	}
 }

--- a/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/AppDeployerTests.java
+++ b/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/AppDeployerTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.app;
+
+import org.junit.Test;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link AppDeployer}
+ */
+public class AppDeployerTests {
+
+	@Test
+	public void testAppDeployerGetLogDefaultMethod() {
+		AppDeployer customAppDeployer = new AppDeployer() {
+			@Override
+			public String deploy(AppDeploymentRequest request) {
+				return "Deployment request received.";
+			}
+
+			@Override
+			public void undeploy(String id) {
+			}
+
+			@Override
+			public AppStatus status(String id) {
+				return AppStatus.of("id").build();
+			}
+
+			@Override
+			public RuntimeEnvironmentInfo environmentInfo() {
+				return new RuntimeEnvironmentInfo.Builder().build();
+			}
+		};
+		try {
+			customAppDeployer.getLog("test");
+			fail();
+		}
+		catch (UnsupportedOperationException e) {
+			assertEquals(e.getMessage(), "'getLog' is not implemented.");
+		}
+
+	}
+}

--- a/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/RuntimeEnvironmentInfoBuilderTests.java
+++ b/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/RuntimeEnvironmentInfoBuilderTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.spi.app;
 
 import org.junit.Test;
+
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.core.SpringVersion;

--- a/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/task/TaskLauncherTests.java
+++ b/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/task/TaskLauncherTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.task;
+
+import org.junit.Test;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link TaskLauncher}
+ */
+public class TaskLauncherTests {
+
+	@Test
+	public void testTaskLauncherDefaultMethods() {
+
+		TaskLauncher taskLauncher = new TaskLauncher() {
+			@Override
+			public String launch(AppDeploymentRequest request) {
+				return null;
+			}
+
+			@Override
+			public void cancel(String id) {
+
+			}
+
+			@Override
+			public TaskStatus status(String id) {
+				return null;
+			}
+
+			@Override
+			public void cleanup(String id) {
+
+			}
+
+			@Override
+			public void destroy(String appName) {
+
+			}
+
+			@Override
+			public RuntimeEnvironmentInfo environmentInfo() {
+				return null;
+			}
+		};
+		try {
+			taskLauncher.getLog("test");
+			fail();
+		}
+		catch (UnsupportedOperationException e) {
+			assertEquals(e.getMessage(), "'getLog' is not implemented.");
+		}
+		try {
+			taskLauncher.getRunningTaskExecutionCount();
+			fail();
+		}
+		catch (UnsupportedOperationException e) {
+			assertEquals(e.getMessage(), "'getRunningTaskExecutionCount' is not implemented.");
+		}
+		try {
+			taskLauncher.getMaximumConcurrentTasks();
+			fail();
+		}
+		catch (UnsupportedOperationException e) {
+			assertEquals(e.getMessage(), "'getMaximumConcurrentTasks' is not implemented.");
+		}
+	}
+}


### PR DESCRIPTION
 - In both the AppDeployer/TaskLauncher SPI interfaces, adda default method for `getLog` which throws the UnsupportedOperationException

 - Add tests

Resolves #315