### PR TITLE
Change scale() to take an AppScaleRequest

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
+import org.springframework.cloud.deployer.spi.app.AppScaleRequest;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
@@ -458,7 +459,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Scaling {} to {} instances...", request.getDefinition().getName(), DESIRED_COUNT);
 
-		appDeployer().scale(request.getDefinition().getName(), DESIRED_COUNT);
+		appDeployer().scale(new AppScaleRequest(request.getDefinition().getName(), DESIRED_COUNT));
 
 		assertThat(deploymentId, eventually(hasStatusThat(
 			Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
@@ -475,7 +476,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 
 		log.info("Scaling {} from {} to 1 instance...", request.getDefinition().getName(),DESIRED_COUNT);
 
-		appDeployer().scale(request.getDefinition().getName(), 1);
+		appDeployer().scale(new AppScaleRequest(request.getDefinition().getName(), 1));
 
 		assertThat(deploymentId, eventually(hasStatusThat(
 			Matchers.<AppStatus>hasProperty("state", is(partial))), timeout.maxAttempts, timeout.pause));
@@ -567,8 +568,8 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		}
 
 		@Override
-		public void scale(String id, int desiredCount) {
-			wrapped.scale(id, desiredCount);
+		public void scale(AppScaleRequest appScaleRequest) {
+			wrapped.scale(appScaleRequest);
 		}
 
 	}

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -156,12 +156,11 @@ public interface AppDeployer {
 	}
 
 	/**
-	 * Scale an app to the desired count.
+	 * Scale an app according to given values.
 	 *
-	 * @param id the app deployment id, as returned by {@link #deploy}
-	 * @param desiredCount the desired number of instances.
+	 * @param appScaleRequest an {@link AppScaleRequest}.
 	 */
-	 default void scale(String id, int desiredCount) {
+	 default void scale(AppScaleRequest appScaleRequest) {
 		throw new UnsupportedOperationException("'scale' is not implemented.");
 	}
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppScaleRequest.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppScaleRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.app;
+
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Representation of an app scale request. This includes the application's deployment Id, the number of desired
+ * instances, and optionally, properties that may be applied during the scaling operation.
+ *
+ * @author David Turanski
+ * @since 2.1.0
+ */
+public class AppScaleRequest {
+    private final int desiredInstanceCount;
+    private final String deploymentId;
+    private final Optional<Map<String,Object>> properties;
+
+    /**
+     *
+     * @param deploymentId the unique deployment ID of the application.
+     * @param desiredInstanceCount the desired instance count.
+     */
+    public AppScaleRequest(String deploymentId, int desiredInstanceCount) {
+        this(deploymentId, desiredInstanceCount, null);
+    }
+
+    /**
+     *
+     * @param deploymentId the unique deployment ID of the application.
+     * @param desiredInstanceCount the desired instance count.
+     * @param properties optional properties that may be applied during the scale operation.
+     */
+    public AppScaleRequest(String deploymentId, int desiredInstanceCount, @Nullable  Map<String, Object> properties) {
+        Assert.hasText(deploymentId,"'deploymentId', must not be empty or null");
+        Assert.state(desiredInstanceCount >= 0, "'desiredInstanceCount' must be >= 0");
+        this.deploymentId = deploymentId;
+        this.desiredInstanceCount = desiredInstanceCount;
+        this.properties = Optional.ofNullable(properties);
+    }
+
+    /**
+     *
+     * @return the desired instance count.
+     */
+    public int getDesiredInstanceCount() {
+        return desiredInstanceCount;
+    }
+
+    /**
+     *
+     * @return the deployment ID.
+     */
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
+    /**
+     *
+     * @return the {@link Optional} properties.
+     */
+    public Optional<Map<String, Object>> getProperties() {
+        return properties;
+    }
+}

--- a/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/AppDeployerTests.java
+++ b/spring-cloud-deployer-spi/src/test/java/org/springframework/cloud/deployer/spi/app/AppDeployerTests.java
@@ -52,7 +52,7 @@ public class AppDeployerTests {
 			}
 
 			@Override
-			public void scale(String id, int desiredCount) {
+			public void scale(AppScaleRequest appScaleRequest) {
 
 			}
 		};


### PR DESCRIPTION
change `scale(id, int)` to `scale(appScaleRequest)` to allow for extensibility.