### PR TITLE
Support for eventual app instance count matching

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractAppDeployerIntegrationTests.java
@@ -464,7 +464,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		assertThat(deploymentId, eventually(hasStatusThat(
 			Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
 
-		assertThat(appDeployer().status(deploymentId).getInstances().size(), is(DESIRED_COUNT));
+		assertThat(deploymentId, eventually(appInstanceCount(is(DESIRED_COUNT)), timeout.maxAttempts, timeout.pause));
 
 		List<DeploymentState> individualStates = new ArrayList<>();
 		for (AppInstanceStatus status : appDeployer().status(deploymentId).getInstances().values()) {
@@ -480,7 +480,7 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		assertThat(deploymentId, eventually(hasStatusThat(
 			Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
 
-		assertThat(appDeployer().status(deploymentId).getInstances().size(), is(1));
+		assertThat(deploymentId, eventually(appInstanceCount(is(1)), timeout.maxAttempts, timeout.pause));
 
 		log.info("Undeploying {}...", deploymentId);
 
@@ -488,6 +488,14 @@ public abstract class AbstractAppDeployerIntegrationTests extends AbstractIntegr
 		appDeployer().undeploy(deploymentId);
 		assertThat(deploymentId, eventually(hasStatusThat(
 			Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+	}
+
+	/**
+	 * A Hamcrest Matcher that queries the number of app instances for some app id.
+	 * @param countMatcher number of app instances to match.
+	 */
+	protected Matcher<String> appInstanceCount(final Matcher<Integer> countMatcher) {
+		return AppCountMatcher.hasAppCount(countMatcher, appDeployer());
 	}
 
 	/**

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AppCountMatcher.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AppCountMatcher.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.test;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AppCountMatcher extends BaseMatcher<String> {
+
+	private final Matcher<Integer> delegate;
+	private final AppDeployer appDeployer;
+	private Integer appInstanceCount;
+
+	public AppCountMatcher(Matcher<Integer> delegate, AppDeployer appDeployer) {
+		this.delegate = delegate;
+		this.appDeployer = appDeployer;
+	}
+
+	@Override
+	public boolean matches(Object actual) {
+		appInstanceCount = appDeployer.status((String) actual).getInstances().size();
+		return delegate.matches(appInstanceCount);
+
+	}
+
+	@Override
+	public void describeMismatch(Object item, Description mismatchDescription) {
+		mismatchDescription.appendText("App instance count of ").appendValue(item).appendText(" ");
+		delegate.describeMismatch(appInstanceCount, mismatchDescription);
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		delegate.describeTo(description);
+	}
+
+	public static AppCountMatcher hasAppCount(Matcher<Integer> delegate, AppDeployer appDeployer) {
+		return new AppCountMatcher(delegate, appDeployer);
+	}
+}


### PR DESCRIPTION
 - Add AppCountMatcher class
 - Add AbstractAppDeployerIntegrationTests#appInstanceCount helper method
 - Update doScaleTest to use the eventually(appInstanceCount(is(DESIRED_COUNT))) check.

 Resolves #323