### PR TITLE
Upgrade maven deps to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<maven.version>3.5.4</maven.version>
-		<maven-resolver.version>1.1.1</maven-resolver.version>
+		<maven.version>3.6.2</maven.version>
+		<maven-resolver.version>1.4.1</maven-resolver.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
- Change maven and maven resolver deps to 3.6.2 and
  1.4.1 respectively.
- Main inpact is that this now removes guava from transitive
  deps who need to consume maven resource.
- Fixes #326