### PR TITLE
Move to spring-cloud-dataflow-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-build</artifactId>
-		<version>2.2.0.RELEASE</version>
+		<artifactId>spring-cloud-dataflow-build</artifactId>
+		<version>2.4.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
- Simple change to use spring-cloud-dataflow-build instead
  of spring-cloud-build.
- Relates spring-cloud/spring-cloud-dataflow#3670