### PR TITLE
Add wagon based http transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<java.version>1.8</java.version>
 		<maven.version>3.6.2</maven.version>
 		<maven-resolver.version>1.4.1</maven-resolver.version>
+		<maven-wagon.version>3.3.4</maven-wagon.version>
 	</properties>
 
 	<modules>
@@ -51,6 +52,11 @@
 				<version>2.2.0.BUILD-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-http</artifactId>
+				<version>${maven-wagon.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -15,10 +15,6 @@
 		<version>2.2.0.BUILD-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -51,21 +47,40 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>
+			<artifactId>maven-resolver-transport-wagon</artifactId>
+			<version>${maven-resolver.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.resolver</groupId>
 			<artifactId>maven-resolver-impl</artifactId>
 			<version>${maven-resolver.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.wagon</groupId>
+			<artifactId>wagon-http</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-web</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/MavenProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.resource.maven;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -78,6 +79,19 @@ public class MavenProperties {
 	 * Add the ConsoleRepositoryListener to the session for debugging of artifact resolution.
 	 */
 	private boolean enableRepositoryListener = false;
+
+	/**
+	 * Use maven wagon based transport for http based artifacts.
+	 */
+	private boolean useWagon;
+
+	public void setUseWagon(boolean useWagon) {
+		this.useWagon = useWagon;
+	}
+
+	public boolean isUseWagon() {
+		return useWagon;
+	}
 
 	public boolean isEnableRepositoryListener() {
 		return enableRepositoryListener;
@@ -228,6 +242,85 @@ public class MavenProperties {
 		}
 	}
 
+	public static enum WagonHttpMethod {
+		// directly maps to http methods in org.apache.maven.wagon.shared.http.HttpConfiguration
+		all,
+		get,
+		put,
+		head;
+	}
+
+	public static class WagonHttpMethodProperties {
+		// directly maps to settings in org.apache.maven.wagon.shared.http.HttpMethodConfiguration
+		private boolean usePreemptive;
+		private boolean useDefaultHeaders;
+		private Integer connectionTimeout;
+		private Integer readTimeout;
+		private Map<String, String> headers = new HashMap<>();
+		private Map<String, String> params = new HashMap<>();
+
+		public boolean isUsePreemptive() {
+			return usePreemptive;
+		}
+
+		public void setUsePreemptive(boolean usePreemptive) {
+			this.usePreemptive = usePreemptive;
+		}
+
+		public boolean isUseDefaultHeaders() {
+			return useDefaultHeaders;
+		}
+
+		public void setUseDefaultHeaders(boolean useDefaultHeaders) {
+			this.useDefaultHeaders = useDefaultHeaders;
+		}
+
+		public Integer getConnectionTimeout() {
+			return connectionTimeout;
+		}
+
+		public void setConnectionTimeout(Integer connectionTimeout) {
+			this.connectionTimeout = connectionTimeout;
+		}
+
+		public Integer getReadTimeout() {
+			return readTimeout;
+		}
+
+		public void setReadTimeout(Integer readTimeout) {
+			this.readTimeout = readTimeout;
+		}
+
+		public Map<String, String> getHeaders() {
+			return headers;
+		}
+
+		public void setHeaders(Map<String, String> headers) {
+			this.headers = headers;
+		}
+
+		public Map<String, String> getParams() {
+			return params;
+		}
+
+		public void setParams(Map<String, String> params) {
+			this.params = params;
+		}
+	}
+
+	public static class Wagon {
+
+		private Map<WagonHttpMethod, WagonHttpMethodProperties> http = new HashMap<>();
+
+		public Map<WagonHttpMethod, WagonHttpMethodProperties> getHttp() {
+			return http;
+		}
+
+		public void setHttp(Map<WagonHttpMethod, WagonHttpMethodProperties> http) {
+			this.http = http;
+		}
+	}
+
 	public static class RemoteRepository {
 
 		/**
@@ -243,6 +336,8 @@ public class MavenProperties {
 
 		private RepositoryPolicy releasePolicy;
 
+		private Wagon wagon = new Wagon();
+
 		public RemoteRepository() {
 		}
 
@@ -253,6 +348,14 @@ public class MavenProperties {
 		public RemoteRepository(final String url, final Authentication auth) {
 			this.url = url;
 			this.auth = auth;
+		}
+
+		public Wagon getWagon() {
+			return wagon;
+		}
+
+		public void setWagon(Wagon wagon) {
+			this.wagon = wagon;
 		}
 
 		public String getUrl() {

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/StaticWagonConfigurator.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/StaticWagonConfigurator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.resource.maven;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Map.Entry;
+
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.providers.http.HttpWagon;
+import org.apache.maven.wagon.shared.http.HttpConfiguration;
+import org.apache.maven.wagon.shared.http.HttpMethodConfiguration;
+import org.eclipse.aether.transport.wagon.WagonConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.WagonHttpMethod;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.WagonHttpMethodProperties;
+
+/**
+ * Simple implementation of a {@link WagonConfigurator} which creates and supports
+ * those providers we need. Maven resolver itself only provides PlexusWagonConfigurator
+ * which is more involved with actual maven pom configuration and would not
+ * suit our needs as things get a bit crazy with it due to its use of Guice.
+ *
+ * @author Janne Valkealahti
+ */
+public class StaticWagonConfigurator implements WagonConfigurator {
+
+	private static final Logger log = LoggerFactory.getLogger(StaticWagonConfigurator.class);
+
+	@Override
+	public void configure(Wagon wagon, Object configuration) throws Exception {
+		log.debug("Configuring wagon {} with {}", wagon, configuration);
+		if (wagon instanceof HttpWagon && configuration instanceof MavenProperties.Wagon) {
+			HttpWagon httpWagon = (HttpWagon)wagon;
+			Map<WagonHttpMethod, WagonHttpMethodProperties> httpMethodProperties = ((MavenProperties.Wagon) configuration)
+					.getHttp();
+			HttpConfiguration httpConfiguration = new HttpConfiguration();
+			for (Entry<WagonHttpMethod, WagonHttpMethodProperties> entry : httpMethodProperties.entrySet()) {
+				switch (entry.getKey()) {
+					case all:
+						httpConfiguration.setAll(buildConfig(entry.getValue()));
+						break;
+					case get:
+						httpConfiguration.setGet(buildConfig(entry.getValue()));
+						break;
+					case head:
+						httpConfiguration.setHead(buildConfig(entry.getValue()));
+						break;
+					case put:
+						httpConfiguration.setPut(buildConfig(entry.getValue()));
+						break;
+					default:
+						break;
+				}
+			}
+			httpWagon.setHttpConfiguration(httpConfiguration);
+		}
+	}
+
+	private static HttpMethodConfiguration buildConfig(WagonHttpMethodProperties properties) {
+		HttpMethodConfiguration config = new HttpMethodConfiguration();
+		config.setUsePreemptive(properties.isUsePreemptive());
+		config.setUseDefaultHeaders(properties.isUseDefaultHeaders());
+		if (properties.getConnectionTimeout() != null) {
+			config.setConnectionTimeout(properties.getConnectionTimeout());
+		}
+		if (properties.getReadTimeout() != null) {
+			config.setReadTimeout(properties.getReadTimeout());
+		}
+		Properties params = new Properties();
+		params.putAll(properties.getParams());
+		config.setParams(params);
+		Properties headers = new Properties();
+		headers.putAll(properties.getHeaders());
+		config.setHeaders(headers);
+		return config;
+	}
+}

--- a/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/StaticWagonProvider.java
+++ b/spring-cloud-deployer-resource-maven/src/main/java/org/springframework/cloud/deployer/resource/maven/StaticWagonProvider.java
@@ -1,0 +1,54 @@
+package org.springframework.cloud.deployer.resource.maven;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.providers.http.HttpWagon;
+import org.eclipse.aether.transport.wagon.WagonProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple implementation of a {@link WagonProvider} which creates and supports
+ * those providers we need. Maven resolver itself only provides PlexusWagonProvider
+ * which is more involved with actual maven pom configuration and would not
+ * suit our needs as things get a bit crazy with it due to its use of Guice.
+ *
+ * @author Janne Valkealahti
+ */
+public class StaticWagonProvider implements WagonProvider {
+
+	private static final Logger log = LoggerFactory.getLogger(StaticWagonProvider.class);
+
+	public StaticWagonProvider() {
+	}
+
+	public Wagon lookup( String roleHint ) throws Exception {
+		log.debug("Looking up wagon for roleHint {}", roleHint);
+		if ("http".equals(roleHint)) {
+			return new HttpWagon();
+		}
+		throw new IllegalArgumentException("No wagon available for " + roleHint);
+	}
+
+	public void release(Wagon wagon) {
+		// nothing to do now
+	}
+}

--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenExtension.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenExtension.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.resource.maven;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Simple junit5 extension which bootstraps a server to simulate various
+ * scenarious for artifact resolving via http.
+ *
+ * @author Janne Valkealahti
+ */
+public class MavenExtension implements AfterEachCallback, BeforeEachCallback {
+
+	private ConfigurableApplicationContext context;
+
+	public int getPort() {
+		return Integer.parseInt(this.context.getEnvironment().getProperty("local.server.port"));
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		SpringApplication application = new SpringApplication(ServerConfig.class);
+		this.context = application.run("--server.port=0");
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		if (this.context != null) {
+			this.context.close();
+		}
+		this.context = null;
+	}
+
+	@SpringBootApplication
+	static class ServerConfig {
+	}
+
+	@RestController
+	@RequestMapping("/public")
+	static class PublicRepoController {
+
+		@GetMapping(path = "/org/example/app/1.0.0.RELEASE/app-1.0.0.RELEASE.jar")
+		public byte[] app100release() {
+			return new byte[0];
+		}
+
+	}
+
+	@RestController
+	@RequestMapping("/private")
+	static class PrivateRepoController {
+
+		@GetMapping(path = "/org/example/secured/1.0.0.RELEASE/secured-1.0.0.RELEASE.jar")
+		public byte[] secured100release() {
+			return new byte[0];
+		}
+
+	}
+
+	@RestController
+	@RequestMapping("/preemptive")
+	@EnableWebSecurity
+	static class PreemptiveRepoController {
+
+		@GetMapping(path = "/org/example/preemptive/1.0.0.RELEASE/preemptive-1.0.0.RELEASE.jar")
+		public byte[] preemptive100release() {
+			return new byte[0];
+		}
+
+	}
+
+	@Configuration
+	static class BasicSecurityConfig extends WebSecurityConfigurerAdapter {
+
+		@Bean
+		public UserDetailsService userDetailsService() {
+			UserBuilder users = User.builder();
+			InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+			manager.createUser(users.username("user").password("{noop}password").roles("USER").build());
+			return manager;
+		}
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+
+			// We add basic auth for /private so server returns 401 and
+			// challenge happens with maven client.
+
+			http
+				.authorizeRequests()
+					.antMatchers("/public/**").permitAll()
+					.antMatchers("/private/**").hasRole("USER")
+					.and()
+				.httpBasic();
+		}
+	}
+
+	@Configuration
+	@Order(1)
+	static class PreemptiveSecurityConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+
+			// We add basic auth for /preemptive so server returns 403 as
+			// exception handling is changed to force 403.
+			// normal maven behaviour is that it needs 401 to continue with a challenge.
+			// This is where preemptive auth takes place as client should send auth
+			// with every request.
+
+			http
+				.antMatcher("/preemptive/**")
+				.authorizeRequests(authorizeRequests ->
+                    authorizeRequests.anyRequest().hasRole("USER")
+				)
+				.httpBasic()
+					.and()
+				.exceptionHandling()
+					.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.FORBIDDEN));
+		}
+	}
+}

--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenPropertiesTests.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenPropertiesTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.resource.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.WagonHttpMethod;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+public class MavenPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	public void testDefaults() {
+		this.contextRunner
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				MavenProperties properties = context.getBean(MavenProperties.class);
+				assertThat(properties.isUseWagon()).isFalse();
+			});
+	}
+
+	@Test
+	public void testPreemtiveEnabled() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("maven.use-wagon", "true");
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				MavenProperties properties = context.getBean(MavenProperties.class);
+				assertThat(properties.isUseWagon()).isTrue();
+			});
+	}
+
+	@Test
+	public void testRemoteRepositories() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("maven.remote-repositories.repo1.url", "url1");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.use-preemptive", "true");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.use-default-headers", "true");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.connection-timeout", "2");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.read-timeout", "3");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.headers.header1", "value1");
+				map.put("maven.remote-repositories.repo1.wagon.http.all.params.http.connection.timeout", "1");
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				MavenProperties properties = context.getBean(MavenProperties.class);
+				assertThat(properties.getRemoteRepositories().size()).isEqualTo(1);
+				assertThat(properties.getRemoteRepositories()).containsOnlyKeys("repo1");
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp().size())
+					.isEqualTo(1);
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).isUsePreemptive()).isTrue();
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).isUseDefaultHeaders()).isTrue();
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getConnectionTimeout()).isEqualTo(2);
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getReadTimeout()).isEqualTo(3);
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getHeaders()).containsOnlyKeys("header1");
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getHeaders().get("header1")).isEqualTo("value1");
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getParams()).containsOnlyKeys("http.connection.timeout");
+				assertThat(properties.getRemoteRepositories().get("repo1").getWagon().getHttp()
+					.get(WagonHttpMethod.all).getParams().get("http.connection.timeout")).isEqualTo("1");
+				});
+	}
+
+	@EnableConfigurationProperties({ MavenConfigurationProperties.class })
+	private static class Config1 {
+	}
+
+	@ConfigurationProperties(prefix = "maven")
+	public static class MavenConfigurationProperties extends MavenProperties {
+	}
+}

--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/WagonHttpTests.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/WagonHttpTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.resource.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.Authentication;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.RemoteRepository;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.WagonHttpMethod;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties.WagonHttpMethodProperties;
+
+public class WagonHttpTests {
+
+	@RegisterExtension
+	static MavenExtension server = new MavenExtension();
+
+	@Test
+	public void resourceDoesNotExistWagon(@TempDir Path tempDir) {
+		MavenProperties mavenProperties = new MavenProperties();
+		mavenProperties.setLocalRepository(tempDir.toAbsolutePath().toString());
+		mavenProperties.setUseWagon(true);
+		Map<String, MavenProperties.RemoteRepository> remoteRepositoryMap = new HashMap<>();
+		remoteRepositoryMap.put("default",
+				new MavenProperties.RemoteRepository("http://localhost:" + server.getPort() + "/public"));
+		mavenProperties.setRemoteRepositories(remoteRepositoryMap);
+		MavenResource resource = MavenResource
+				.parse("org.example:doesnotexist:jar:1.0.0.RELEASE", mavenProperties);
+		assertThat(resource.exists()).isFalse();
+	}
+
+	@Test
+	public void resourceDoesExistWagon(@TempDir Path tempDir) {
+		MavenProperties mavenProperties = new MavenProperties();
+		mavenProperties.setLocalRepository(tempDir.toAbsolutePath().toString());
+		mavenProperties.setUseWagon(true);
+		Map<String, MavenProperties.RemoteRepository> remoteRepositoryMap = new HashMap<>();
+		remoteRepositoryMap.put("default",
+				new MavenProperties.RemoteRepository("http://localhost:" + server.getPort() + "/public"));
+		mavenProperties.setRemoteRepositories(remoteRepositoryMap);
+		MavenResource resource = MavenResource
+				.parse("org.example:app:jar:1.0.0.RELEASE", mavenProperties);
+		assertThat(resource.exists()).isTrue();
+	}
+
+	@Test
+	public void resourceDoesExistWithAuth(@TempDir Path tempDir) {
+		MavenProperties mavenProperties = new MavenProperties();
+		mavenProperties.setLocalRepository(tempDir.toAbsolutePath().toString());
+		mavenProperties.setUseWagon(true);
+		Map<String, RemoteRepository> remoteRepositories = new HashMap<>();
+		RemoteRepository remoteRepository = new RemoteRepository("http://localhost:" + server.getPort() + "/private");
+		Authentication auth = new Authentication("user", "password");
+		remoteRepository.setAuth(auth);
+		remoteRepositories.put("default", remoteRepository);
+		mavenProperties.setRemoteRepositories(remoteRepositories);
+		MavenResource resource = MavenResource
+				.parse("org.example:secured:jar:1.0.0.RELEASE", mavenProperties);
+		assertThat(resource.exists()).isTrue();
+	}
+
+	@Test
+	public void resourceDoesExistWithPreemptiveAuth(@TempDir Path tempDir) {
+		MavenProperties mavenProperties = new MavenProperties();
+		mavenProperties.setLocalRepository(tempDir.toAbsolutePath().toString());
+
+		mavenProperties.setUseWagon(true);
+		Map<String, RemoteRepository> remoteRepositories = new HashMap<>();
+		RemoteRepository remoteRepository = new RemoteRepository("http://localhost:" + server.getPort() + "/preemptive");
+		WagonHttpMethodProperties wagonHttpMethodProperties = new WagonHttpMethodProperties();
+		wagonHttpMethodProperties.setUsePreemptive(true);
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Foo", "Bar");
+		Map<String, String> params = new HashMap<>();
+		params.put("http.connection.stalecheck", "true");
+		wagonHttpMethodProperties.setHeaders(headers);
+		wagonHttpMethodProperties.setParams(params);
+
+		remoteRepository.getWagon().getHttp().put(WagonHttpMethod.all, wagonHttpMethodProperties);
+		Authentication auth = new Authentication("user", "password");
+		remoteRepository.setAuth(auth);
+		remoteRepositories.put("default", remoteRepository);
+		mavenProperties.setRemoteRepositories(remoteRepositories);
+		MavenResource resource = MavenResource
+				.parse("org.example:preemptive:jar:1.0.0.RELEASE", mavenProperties);
+		assertThat(resource.exists()).isTrue();
+	}
+}

--- a/spring-cloud-deployer-resource-maven/src/test/resources/application.properties
+++ b/spring-cloud-deployer-resource-maven/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+logging.level.org.springframework.cloud.deployer=debug
+logging.level.org.springframework.web=debug
+logging.level.org.apache.http.headers=debug


### PR DESCRIPTION
- Order to support preemptive auth need to add wagon http
  as this feature exists only in there.
- Conditionally switch to wagon based http with `maven.use-wagon`
- StaticWagonProvider and StaticWagonConfigurator are a replacement
  for similar classes in a maven resolver core which would only work
  via Plexux containers which are impossible to use in our code base
  as those are mean for real maven dynamic classloading extensions
  with real builds.
- We simply do a static configuration to add `HttpWagon` and its
  configuration which is mapped from `MavenProperties`
- New MavenExtension junit5 concept to mock http endpoints for maven,
  this is something what other tests could use as well.
- Start adding tests for `MavenProperties`.
- Generic list of settings include httpclient params and headers, etc
    wagon.http.all.use-preemptive
    wagon.http.all.use-default-headers
    wagon.http.all.connection-timeout
    wagon.http.all.read-timeout
    wagon.http.all.headers.header1
    wagon.http.all.params.http.connection.timeout
- Method value can be `all`, `put`, `get` or `head` or combination.
- Fixes #331

For an actual dataflow fatjar this causes these additions:
```
98a100
> BOOT-INF/lib/maven-resolver-transport-wagon-1.4.1.jar
218a221,223
> BOOT-INF/lib/wagon-http-3.3.4.jar
> BOOT-INF/lib/wagon-http-shared-3.3.4.jar
> BOOT-INF/lib/wagon-provider-api-3.0.0.jar
```