### PR TITLE
Bugfix 242 - MavenArtifactResolver disregards the non-proxy-hosts configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-build</artifactId>
-		<version>2.4.0.RELEASE</version>
+		<version>2.4.1.RELEASE</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-deployer-parent</artifactId>
-	<version>2.2.1.BUILD-SNAPSHOT</version>
+	<version>2.2.2.BUILD-SNAPSHOT</version>
 	<groupId>org.springframework.cloud</groupId>
 	<packaging>pom</packaging>
 
@@ -49,7 +49,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-dependencies</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-deployer-parent</artifactId>
-	<version>2.2.2.BUILD-SNAPSHOT</version>
+	<version>2.2.2.RELEASE</version>
 	<groupId>org.springframework.cloud</groupId>
 	<packaging>pom</packaging>
 
@@ -49,7 +49,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-dependencies</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-deployer-autoconfigure/pom.xml
+++ b/spring-cloud-deployer-autoconfigure/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-autoconfigure/pom.xml
+++ b/spring-cloud-deployer-autoconfigure/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-dependencies/pom.xml
+++ b/spring-cloud-deployer-dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<version>2.2.1.BUILD-SNAPSHOT</version>
+	<version>2.2.2.BUILD-SNAPSHOT</version>
 	<artifactId>spring-cloud-deployer-dependencies</artifactId>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Deployer Dependencies</name>
@@ -18,27 +18,27 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-docker</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-support</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-spi</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-autoconfigure</artifactId>
-				<version>2.2.1.BUILD-SNAPSHOT</version>
+				<version>2.2.2.BUILD-SNAPSHOT</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-deployer-dependencies/pom.xml
+++ b/spring-cloud-deployer-dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<version>2.2.2.BUILD-SNAPSHOT</version>
+	<version>2.2.2.RELEASE</version>
 	<artifactId>spring-cloud-deployer-dependencies</artifactId>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Deployer Dependencies</name>
@@ -18,27 +18,27 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-docker</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-support</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-spi</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-autoconfigure</artifactId>
-				<version>2.2.2.BUILD-SNAPSHOT</version>
+				<version>2.2.2.RELEASE</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-deployer-resource-docker/pom.xml
+++ b/spring-cloud-deployer-resource-docker/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-resource-docker/pom.xml
+++ b/spring-cloud-deployer-resource-docker/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
@@ -1,0 +1,99 @@
+package org.springframework.cloud.deployer.resource.maven;
+
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eric Chen
+ */
+class MavenArtifactResolverTests {
+
+    @Test
+    void testResolve_fail_onProxy_UnknownHostException() {
+        String location = "maven://foo:bar:1.0.1";
+        MavenResourceLoader loader = new MavenResourceLoader(new MavenProperties());
+        Resource resource = loader.getResource(location);
+        assertEquals(MavenResource.class, resource.getClass());
+        MavenResource mavenResource = (MavenResource) resource;
+
+        //HttpTransporterFactory transporterFactory = Mockito.mock(HttpTransporterFactory.class);
+        MavenArtifactResolver resolver = new MavenArtifactResolver(mavenPropertiesWithProxyRepo());
+
+        try {
+            resolver.resolve(mavenResource);
+            fail();
+        } catch (Exception e) {
+            UnknownHostException ex = (UnknownHostException)e.getCause().getCause().getCause();
+            Assert.assertEquals(ex.getMessage(), "http://proxy.example.com: nodename nor servname provided, or not known");
+        }
+        //resolver.resolve(mvnresource);
+    }
+
+    @Test
+    void testResolve_fail_onNoProxy_IllegalArgumentException() {
+        String location = "maven://foo:bar:1.0.1";
+        MavenResourceLoader loader = new MavenResourceLoader(new MavenProperties());
+        Resource resource = loader.getResource(location);
+        assertEquals(MavenResource.class, resource.getClass());
+        MavenResource mavenResource = (MavenResource) resource;
+
+        //HttpTransporterFactory transporterFactory = Mockito.mock(HttpTransporterFactory.class);
+        MavenArtifactResolver resolver = new MavenArtifactResolver(mavenPropertiesWithNoProxyRepo());
+
+        try {
+            resolver.resolve(mavenResource);
+            fail();
+        } catch (Exception e) {
+            IllegalArgumentException ex = (IllegalArgumentException)e.getCause().getCause().getCause();
+            Assert.assertEquals(ex.getMessage(), "port out of range:99999");
+        }
+        //resolver.resolve(mvnresource);
+    }
+
+    private MavenProperties mavenPropertiesWithProxyRepo() {
+        MavenProperties mavenProperties = new MavenProperties();
+        mavenProperties.setLocalRepository("~/.m2");
+
+        MavenProperties.RemoteRepository remoteRepo2 = new MavenProperties.RemoteRepository();
+        remoteRepo2.setUrl("http://myrepo.com:99999");
+        mavenProperties.getRemoteRepositories().put("repo2", remoteRepo2);
+
+        MavenProperties.Proxy proxy = new MavenProperties.Proxy();
+        proxy.setHost("http://proxy.example.com");
+        proxy.setPort(8080);
+        proxy.setNonProxyHosts("apache*|*.springframework.org|127.0.0.1|localhost");
+        mavenProperties.setProxy(proxy);
+
+        return mavenProperties;
+    }
+
+    private MavenProperties mavenPropertiesWithNoProxyRepo() {
+        MavenProperties mavenProperties = new MavenProperties();
+        mavenProperties.setLocalRepository("~/.m2");
+
+        MavenProperties.RemoteRepository remoteRepo1 = new MavenProperties.RemoteRepository();
+        remoteRepo1.setUrl("http://localhost:99999");
+        mavenProperties.getRemoteRepositories().put("repo1", remoteRepo1);
+
+        MavenProperties.Proxy proxy = new MavenProperties.Proxy();
+        proxy.setHost("http://proxy.example.com");
+        proxy.setPort(8080);
+        proxy.setNonProxyHosts("apache*|*.springframework.org|127.0.0.1|localhost");
+        mavenProperties.setProxy(proxy);
+
+        return mavenProperties;
+    }
+}

--- a/spring-cloud-deployer-resource-support/pom.xml
+++ b/spring-cloud-deployer-resource-support/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-resource-support/pom.xml
+++ b/spring-cloud-deployer-resource-support/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-spi-scheduler-test-app/pom.xml
+++ b/spring-cloud-deployer-spi-scheduler-test-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 	<artifactId>spring-cloud-deployer-spi-scheduler-test-app</artifactId>
 	<properties>

--- a/spring-cloud-deployer-spi-scheduler-test-app/pom.xml
+++ b/spring-cloud-deployer-spi-scheduler-test-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-deployer-spi-scheduler-test-app</artifactId>
 	<properties>

--- a/spring-cloud-deployer-spi-test-app/pom.xml
+++ b/spring-cloud-deployer-spi-test-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 	<artifactId>spring-cloud-deployer-spi-test-app</artifactId>
 	<properties>

--- a/spring-cloud-deployer-spi-test-app/pom.xml
+++ b/spring-cloud-deployer-spi-test-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-deployer-spi-test-app</artifactId>
 	<properties>

--- a/spring-cloud-deployer-spi-test/pom.xml
+++ b/spring-cloud-deployer-spi-test/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -33,17 +33,17 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>2.2.1.BUILD-SNAPSHOT</version>
+			<version>2.2.2.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-			<version>2.2.1.BUILD-SNAPSHOT</version>
+			<version>2.2.2.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi-test-app</artifactId>
-			<version>2.2.1.BUILD-SNAPSHOT</version>
+			<version>2.2.2.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-deployer-spi-test/pom.xml
+++ b/spring-cloud-deployer-spi-test/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -33,17 +33,17 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>2.2.2.BUILD-SNAPSHOT</version>
+			<version>2.2.2.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-			<version>2.2.2.BUILD-SNAPSHOT</version>
+			<version>2.2.2.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi-test-app</artifactId>
-			<version>2.2.2.BUILD-SNAPSHOT</version>
+			<version>2.2.2.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-deployer-spi/pom.xml
+++ b/spring-cloud-deployer-spi/pom.xml
@@ -20,6 +20,10 @@
 			<artifactId>spring-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-deployer-spi/pom.xml
+++ b/spring-cloud-deployer-spi/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.1.BUILD-SNAPSHOT</version>
+		<version>2.2.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-spi/pom.xml
+++ b/spring-cloud-deployer-spi/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.2.2.BUILD-SNAPSHOT</version>
+		<version>2.2.2.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/AppDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.cloud.deployer.spi.app;
 
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * SPI defining a runtime environment capable of deploying and managing the
@@ -138,6 +141,26 @@ public interface AppDeployer {
 	 * @return the app deployment status
 	 */
 	AppStatus status(String id);
+
+	/**
+	 * Return the {@link AppStatus} for an app represented by a deployment id.
+	 *
+	 * @param id the app deployment id, as returned by {@link #deploy}
+	 * @return the app deployment status
+	 */
+	default Mono<AppStatus> statusReactive(String id) {
+		return Mono.defer(() -> Mono.just(status(id)));
+	}
+
+	/**
+	 * Return the {@link AppStatus}s for an app represented by a deployment ids.
+	 *
+	 * @param id the app deployment ids, as returned by {@link #deploy}
+	 * @return the app deployment statuses
+	 */
+	default Flux<AppStatus> statusesReactive(String... ids) {
+		return Flux.fromArray(ids).flatMap(id -> statusReactive(id));
+	}
 
 	/**
 	 * Return the environment info for this deployer.

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/MultiStateAppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/app/MultiStateAppDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.springframework.cloud.deployer.spi.app;
 
 import java.util.Map;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Extension of the AppDeployer interface that adds an additional
  * method to return the DeploymentState for a collection of deployment ids.
@@ -31,4 +33,15 @@ public interface MultiStateAppDeployer extends AppDeployer {
 	 * @return a Map of deployment id and DeploymentState
 	 */
 	Map<String, DeploymentState> states(String ... ids);
+
+	/**
+	 * Return the {@link DeploymentState} for all the apps represented by
+	 * a collection of deployment ids.
+	 *
+	 * @param ids the collection of app deployment ids, as returned by {@link #deploy}
+	 * @return a Map of deployment id and DeploymentState
+	 */
+	default Mono<Map<String, DeploymentState>> statesReactive(String ... ids) {
+		return Mono.defer(() -> Mono.just(states(ids)));
+	}
 }


### PR DESCRIPTION
This issue is not resolved. Please reopen.
The proxySelector is setup inside DefaultRepositorySystemSession. 
However, org.eclipse.aether.transport.http.HttpTransporter is not getting proxy from repositorySession, instead it gets proxy from RemoteRepository directly.

`    

    HttpTransporter( RemoteRepository repository, RepositorySystemSession session )
        throws NoTransporterException {

        //... omitted for brevity ...
        proxy = toHost( repository.getProxy() );
        repoAuthContext = AuthenticationContext.forRepository( session, repository );
        proxyAuthContext = AuthenticationContext.forProxy( session, repository );

        state = new LocalState( session, repository, new SslConfig( session, repoAuthContext ) );

        //... omitted for brevity
    }
`

According to document of RepositorySystemSession, the ProxySelector within RepositorySystemSession is not meant for Remote Repository, the repository should have its own Proxy selected.

`

     public interface RepositorySystemSession {
        //... omitted for brevity ...
        /**
         * Gets the proxy selector to use for repositories discovered in artifact descriptors. Note that this selector is
         * not used for remote repositories which are passed as request parameters to the repository system, those
         * repositories are supposed to have their proxy (if any) already set.
         * 
         * @return The proxy selector to use, never {@code null}.
         * @see org.eclipse.aether.repository.RemoteRepository#getProxy()
         * @see RepositorySystem#newResolutionRepositories(RepositorySystemSession, java.util.List)
         */
        ProxySelector getProxySelector();
        //... omitted for brevity ...
    }

`



