### PR TITLE
MavenArtifactResolver disregards the non-proxy-hosts configuration

### DIFF
--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
@@ -1,0 +1,99 @@
+package org.springframework.cloud.deployer.resource.maven;
+
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eric Chen
+ */
+class MavenArtifactResolverTests {
+
+    @Test
+    void testResolve_fail_onProxy_UnknownHostException() {
+        String location = "maven://foo:bar:1.0.1";
+        MavenResourceLoader loader = new MavenResourceLoader(new MavenProperties());
+        Resource resource = loader.getResource(location);
+        assertEquals(MavenResource.class, resource.getClass());
+        MavenResource mavenResource = (MavenResource) resource;
+
+        //HttpTransporterFactory transporterFactory = Mockito.mock(HttpTransporterFactory.class);
+        MavenArtifactResolver resolver = new MavenArtifactResolver(mavenPropertiesWithProxyRepo());
+
+        try {
+            resolver.resolve(mavenResource);
+            fail();
+        } catch (Exception e) {
+            UnknownHostException ex = (UnknownHostException)e.getCause().getCause().getCause();
+            Assert.assertEquals(ex.getMessage(), "http://proxy.example.com: nodename nor servname provided, or not known");
+        }
+        //resolver.resolve(mvnresource);
+    }
+
+    @Test
+    void testResolve_fail_onNoProxy_IllegalArgumentException() {
+        String location = "maven://foo:bar:1.0.1";
+        MavenResourceLoader loader = new MavenResourceLoader(new MavenProperties());
+        Resource resource = loader.getResource(location);
+        assertEquals(MavenResource.class, resource.getClass());
+        MavenResource mavenResource = (MavenResource) resource;
+
+        //HttpTransporterFactory transporterFactory = Mockito.mock(HttpTransporterFactory.class);
+        MavenArtifactResolver resolver = new MavenArtifactResolver(mavenPropertiesWithNoProxyRepo());
+
+        try {
+            resolver.resolve(mavenResource);
+            fail();
+        } catch (Exception e) {
+            IllegalArgumentException ex = (IllegalArgumentException)e.getCause().getCause().getCause();
+            Assert.assertEquals(ex.getMessage(), "port out of range:99999");
+        }
+        //resolver.resolve(mvnresource);
+    }
+
+    private MavenProperties mavenPropertiesWithProxyRepo() {
+        MavenProperties mavenProperties = new MavenProperties();
+        mavenProperties.setLocalRepository("~/.m2");
+
+        MavenProperties.RemoteRepository remoteRepo2 = new MavenProperties.RemoteRepository();
+        remoteRepo2.setUrl("http://myrepo.com:99999");
+        mavenProperties.getRemoteRepositories().put("repo2", remoteRepo2);
+
+        MavenProperties.Proxy proxy = new MavenProperties.Proxy();
+        proxy.setHost("http://proxy.example.com");
+        proxy.setPort(8080);
+        proxy.setNonProxyHosts("apache*|*.springframework.org|127.0.0.1|localhost");
+        mavenProperties.setProxy(proxy);
+
+        return mavenProperties;
+    }
+
+    private MavenProperties mavenPropertiesWithNoProxyRepo() {
+        MavenProperties mavenProperties = new MavenProperties();
+        mavenProperties.setLocalRepository("~/.m2");
+
+        MavenProperties.RemoteRepository remoteRepo1 = new MavenProperties.RemoteRepository();
+        remoteRepo1.setUrl("http://localhost:99999");
+        mavenProperties.getRemoteRepositories().put("repo1", remoteRepo1);
+
+        MavenProperties.Proxy proxy = new MavenProperties.Proxy();
+        proxy.setHost("http://proxy.example.com");
+        proxy.setPort(8080);
+        proxy.setNonProxyHosts("apache*|*.springframework.org|127.0.0.1|localhost");
+        mavenProperties.setProxy(proxy);
+
+        return mavenProperties;
+    }
+}

--- a/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
+++ b/spring-cloud-deployer-resource-maven/src/test/java/org/springframework/cloud/deployer/resource/maven/MavenArtifactResolverTests.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-/**
+ /**
  * @author Eric Chen
  */
 class MavenArtifactResolverTests {
@@ -37,7 +37,7 @@ class MavenArtifactResolverTests {
             fail();
         } catch (Exception e) {
             UnknownHostException ex = (UnknownHostException)e.getCause().getCause().getCause();
-            Assert.assertEquals(ex.getMessage(), "http://proxy.example.com: nodename nor servname provided, or not known");
+            Assert.assertTrue(ex.getMessage().startsWith( "http://proxy.example.com"));
         }
         //resolver.resolve(mvnresource);
     }


### PR DESCRIPTION
This issue #242 is not resolved. Please reopen.
The proxySelector is setup inside DefaultRepositorySystemSession. 
However, org.eclipse.aether.transport.http.HttpTransporter is not getting proxy from repositorySession, instead it gets proxy from Repository directly.

`    

    HttpTransporter( RemoteRepository repository, RepositorySystemSession session )
        throws NoTransporterException {

        //... omitted for brevity ...
        proxy = toHost( repository.getProxy() );
        repoAuthContext = AuthenticationContext.forRepository( session, repository );
        proxyAuthContext = AuthenticationContext.forProxy( session, repository );

        state = new LocalState( session, repository, new SslConfig( session, repoAuthContext ) );

        //... omitted for brevity
    }
`

According to document of RepositorySystemSession, the ProxySelector within RepositorySystemSession is not meant for Remote Repository, the repository should have its own Proxy selected.

`

     public interface RepositorySystemSession {
        //... omitted for brevity ...
        /**
         * Gets the proxy selector to use for repositories discovered in artifact descriptors. Note that this selector is
         * not used for remote repositories which are passed as request parameters to the repository system, those
         * repositories are supposed to have their proxy (if any) already set.
         * 
         * @return The proxy selector to use, never {@code null}.
         * @see org.eclipse.aether.repository.RemoteRepository#getProxy()
         * @see RepositorySystem#newResolutionRepositories(RepositorySystemSession, java.util.List)
         */
        ProxySelector getProxySelector();
        //... omitted for brevity ...
    }

`

