### PR TITLE
Deprecate the use of SchedulerProperties in SchedulerRequest constructor

### DIFF
--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationJUnit5Tests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationJUnit5Tests.java
@@ -195,10 +195,10 @@ public abstract class AbstractSchedulerIntegrationJUnit5Tests {
 		final String INVALID_EXPRESSION = "BAD";
 		String definitionName = randomName();
 		String scheduleName = scheduleName() + definitionName;
-		Map<String, String> properties = new HashMap<>(getSchedulerProperties());
+		Map<String, String> properties = new HashMap<>(getDeploymentProperties());
 		properties.put(SchedulerPropertyKeys.CRON_EXPRESSION, INVALID_EXPRESSION);
 		AppDefinition definition = new AppDefinition(definitionName, properties);
-		ScheduleRequest request = new ScheduleRequest(definition, properties, getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
+		ScheduleRequest request = new ScheduleRequest(definition, properties, getCommandLineArgs(), scheduleName, testApplication());
         assertThatThrownBy(() -> {
             taskScheduler().schedule(request);
         }).isInstanceOf(CreateScheduleException.class);
@@ -271,7 +271,7 @@ public abstract class AbstractSchedulerIntegrationJUnit5Tests {
 
 	private ScheduleRequest createScheduleRequest(String scheduleName, String definitionName) {
 		AppDefinition definition = new AppDefinition(definitionName, getAppProperties());
-		return new ScheduleRequest(definition, getSchedulerProperties(), getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
+		return new ScheduleRequest(definition, getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
 	}
 
 	private void verifySchedule(ScheduleInfo scheduleInfo) {

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationTests.java
@@ -134,6 +134,7 @@ public abstract class AbstractSchedulerIntegrationTests {
 	 * To be implemented by subclasses, which should return the schedulerProperties that
 	 * will be used for the tests.
 	 */
+	@Deprecated
 	protected abstract Map<String, String> getSchedulerProperties();
 
 	/**
@@ -196,10 +197,10 @@ public abstract class AbstractSchedulerIntegrationTests {
 		final String INVALID_EXPRESSION = "BAD";
 		String definitionName = randomName();
 		String scheduleName = scheduleName() + definitionName;
-		Map<String, String> properties = new HashMap<>(getSchedulerProperties());
+		Map<String, String> properties = new HashMap<>(getDeploymentProperties());
 		properties.put(SchedulerPropertyKeys.CRON_EXPRESSION, INVALID_EXPRESSION);
 		AppDefinition definition = new AppDefinition(definitionName, properties);
-		ScheduleRequest request = new ScheduleRequest(definition, properties, getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
+		ScheduleRequest request = new ScheduleRequest(definition, properties, getCommandLineArgs(), scheduleName, testApplication());
 		this.expectedException.expect(CreateScheduleException.class);
 
 		taskScheduler().schedule(request);
@@ -270,7 +271,7 @@ public abstract class AbstractSchedulerIntegrationTests {
 
 	private ScheduleRequest createScheduleRequest(String scheduleName, String definitionName) {
 		AppDefinition definition = new AppDefinition(definitionName, getAppProperties());
-		return new ScheduleRequest(definition, getSchedulerProperties(), getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
+		return new ScheduleRequest(definition, getDeploymentProperties(), getCommandLineArgs(), scheduleName, testApplication());
 	}
 
 	private void verifySchedule(ScheduleInfo scheduleInfo) {

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/scheduler/ScheduleRequest.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/scheduler/ScheduleRequest.java
@@ -58,10 +58,11 @@ public class ScheduleRequest extends AppDeploymentRequest{
 	 * Construct an {@code AppDeploymentRequest}.
 	 *
 	 * @param definition app definition.
-	 * @param schedulerProperties properties that contain scheduler specific informaton.
+	 * @param schedulerProperties properties that contain scheduler specific information.
 	 * @param deploymentProperties map of deployment properties; may be {@code null}.
 	 * @param scheduleName the name associated with the schedule.
 	 */
+	@Deprecated
 	public ScheduleRequest(AppDefinition definition, Map<String, String> schedulerProperties,
 			Map<String, String> deploymentProperties, String scheduleName, Resource resource) {
 		this(definition, schedulerProperties, deploymentProperties, null, scheduleName, resource);
@@ -71,19 +72,47 @@ public class ScheduleRequest extends AppDeploymentRequest{
 	 * Construct an {@code AppDeploymentRequest}.
 	 *
 	 * @param definition app definition
-	 * @param schedulerProperties properties that contain scheduler specific informaton.
+	 * @param schedulerProperties properties that contain scheduler specific information.
 	 * @param deploymentProperties map of deployment properties; may be {@code null}
 	 * @param commandlineArguments set of command line arguments; may be {@code null}
 	 * @param scheduleName the name associated with the schedule.
 	 */
+	@Deprecated
 	public ScheduleRequest(AppDefinition definition,  Map<String, String> schedulerProperties,
 			Map<String, String> deploymentProperties, List<String> commandlineArguments,
 			String scheduleName, Resource resource) {
 		super(definition, resource, deploymentProperties, commandlineArguments);
 		this.scheduleName = scheduleName;
 		this.schedulerProperties = schedulerProperties == null
-				? Collections.<String, String>emptyMap()
+				? Collections.emptyMap()
 				: Collections.unmodifiableMap(schedulerProperties);
+	}
+
+	/**
+	 * Construct an {@code AppDeploymentRequest}.
+	 *
+	 * @param definition app definition.
+	 * @param deploymentProperties map of deployment properties; may be {@code null}.
+	 * @param scheduleName the name associated with the schedule.
+	 */
+	public ScheduleRequest(AppDefinition definition,
+			Map<String, String> deploymentProperties, String scheduleName, Resource resource) {
+		this(definition, deploymentProperties, (List<String>) null, scheduleName, resource);
+	}
+
+	/**
+	 * Construct an {@code AppDeploymentRequest}.
+	 *
+	 * @param definition app definition
+	 * @param deploymentProperties map of deployment properties; may be {@code null}
+	 * @param commandlineArguments set of command line arguments; may be {@code null}
+	 * @param scheduleName the name associated with the schedule.
+	 */
+	public ScheduleRequest(AppDefinition definition,
+			Map<String, String> deploymentProperties, List<String> commandlineArguments,
+			String scheduleName, Resource resource) {
+		super(definition, resource, deploymentProperties, commandlineArguments);
+		this.scheduleName = scheduleName;
 	}
 
 	/**
@@ -93,10 +122,12 @@ public class ScheduleRequest extends AppDeploymentRequest{
 		return scheduleName;
 	}
 
+	@Deprecated
 	public Map<String, String> getSchedulerProperties() {
 		return schedulerProperties;
 	}
 
+	@Deprecated
 	public void setSchedulerProperties(Map<String, String> schedulerProperties) {
 		this.schedulerProperties = schedulerProperties;
 	}


### PR DESCRIPTION
All schedule properties should be passed in via the deployment properties.  
resolves #348

This is a child of https://github.com/spring-cloud/spring-cloud-dataflow/issues/4262