### PR TITLE
Ensure commons-io:2.7 is resolved regardless of which dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<maven.version>3.6.2</maven.version>
 		<maven-resolver.version>1.4.1</maven-resolver.version>
 		<maven-wagon.version>3.3.4</maven-wagon.version>
+		<commons-io.version>2.7</commons-io.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -56,6 +56,11 @@
 			<version>${maven-resolver.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons-io.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-http</artifactId>
 		</dependency>


### PR DESCRIPTION
Ensure commons-io:2.7 is resolved regardless of which dependency is included. 
This resolves https://nvd.nist.gov/vuln/detail/CVE-2021-29425