### PR TITLE
Migrate spring.factories to autoconfiguration.imports per boot standard

### DIFF
--- a/spring-cloud-deployer-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-deployer-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.cloud.deployer.autoconfigure.ResourceLoadingAutoConfiguration

--- a/spring-cloud-deployer-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-deployer-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.cloud.deployer.autoconfigure.ResourceLoadingAutoConfiguration


### PR DESCRIPTION

It is discussed here: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#changes-to-auto-configuration And is required if 3.x boot apps need to use this project.