### PR TITLE
Add random number to k8s task deployment id.

### DIFF
--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -227,7 +227,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	protected String createDeploymentId(AppDeploymentRequest request) {
 		String name = request.getDefinition().getName();
 		Hashids hashids = new Hashids(name, 0, "abcdefghijklmnopqrstuvwxyz1234567890");
-		long idToEncode = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(100);
+		long idToEncode = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000);
 		String hashid = hashids.encode(idToEncode);
 		String deploymentId = name + "-" + hashid;
 		// Kubernetes does not allow . in the name and does not allow uppercase in the name

--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -227,7 +227,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	protected String createDeploymentId(AppDeploymentRequest request) {
 		String name = request.getDefinition().getName();
 		Hashids hashids = new Hashids(name, 0, "abcdefghijklmnopqrstuvwxyz1234567890");
-		long idToEncode = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(100);
+		long idToEncode = System.nanoTime() + ThreadLocalRandom.current().nextInt(100);
 		String hashid = hashids.encode(idToEncode);
 		String deploymentId = name + "-" + hashid;
 		// Kubernetes does not allow . in the name and does not allow uppercase in the name

--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -227,7 +227,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	protected String createDeploymentId(AppDeploymentRequest request) {
 		String name = request.getDefinition().getName();
 		Hashids hashids = new Hashids(name, 0, "abcdefghijklmnopqrstuvwxyz1234567890");
-		long idToEncode = System.nanoTime() + ThreadLocalRandom.current().nextInt(100);
+		long idToEncode = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(100);
 		String hashid = hashids.encode(idToEncode);
 		String deploymentId = name + "-" + hashid;
 		// Kubernetes does not allow . in the name and does not allow uppercase in the name

--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -226,7 +227,8 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	protected String createDeploymentId(AppDeploymentRequest request) {
 		String name = request.getDefinition().getName();
 		Hashids hashids = new Hashids(name, 0, "abcdefghijklmnopqrstuvwxyz1234567890");
-		String hashid = hashids.encode(System.currentTimeMillis());
+		long idToEncode = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(100);
+		String hashid = hashids.encode(idToEncode);
 		String deploymentId = name + "-" + hashid;
 		// Kubernetes does not allow . in the name and does not allow uppercase in the name
 		return deploymentId.replace('.', '-').toLowerCase();


### PR DESCRIPTION
Avoid duplicate deployment id when multiple tasks launched simultaneously.

Fixes #399