### PR TITLE
Retrieve CF log for tasks and  streams

### DIFF
--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
@@ -149,6 +149,9 @@ abstract class AbstractCloudFoundryTaskLauncher extends AbstractCloudFoundryDepl
 	protected TaskStatus toTaskStatus(GetTaskResponse response) {
 		Map<String, String> attributes = new HashMap<>();
 		//retrieve CF-GUID for retrieving logs
+		Assert.notNull(response.getTaskRelationships(), "response must contain task relationships.");
+		Assert.notNull(response.getTaskRelationships().getApp(), "app in the taskRelationships of the response must not be null");
+		Assert.notNull(response.getTaskRelationships().getApp().getData(), "data in the app of the task relationships within the response must not be null");
 		attributes.put("app-cf-guid", response.getTaskRelationships().getApp().getData().getId());
 		switch (response.getState()) {
 		case SUCCEEDED:

--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/AbstractCloudFoundryTaskLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.cloud.deployer.spi.cloudfoundry;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import io.jsonwebtoken.lang.Assert;
 import org.cloudfoundry.client.CloudFoundryClient;
@@ -145,17 +147,20 @@ abstract class AbstractCloudFoundryTaskLauncher extends AbstractCloudFoundryDepl
 	}
 
 	protected TaskStatus toTaskStatus(GetTaskResponse response) {
+		Map<String, String> attributes = new HashMap<>();
+		//retrieve CF-GUID for retrieving logs
+		attributes.put("app-cf-guid", response.getTaskRelationships().getApp().getData().getId());
 		switch (response.getState()) {
 		case SUCCEEDED:
-			return new TaskStatus(response.getId(), LaunchState.complete, null);
+			return new TaskStatus(response.getId(), LaunchState.complete, attributes);
 		case RUNNING:
-			return new TaskStatus(response.getId(), LaunchState.running, null);
+			return new TaskStatus(response.getId(), LaunchState.running, attributes);
 		case PENDING:
-			return new TaskStatus(response.getId(), LaunchState.launching, null);
+			return new TaskStatus(response.getId(), LaunchState.launching, attributes);
 		case CANCELING:
-			return new TaskStatus(response.getId(), LaunchState.cancelled, null);
+			return new TaskStatus(response.getId(), LaunchState.cancelled, attributes);
 		case FAILED:
-			return new TaskStatus(response.getId(), LaunchState.failed, null);
+			return new TaskStatus(response.getId(), LaunchState.failed, attributes);
 		default:
 			throw new IllegalStateException(String.format("Unsupported CF task state %s", response.getState()));
 		}

--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessor.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessor.java
@@ -56,12 +56,11 @@ public class ApplicationLogAccessor {
      * @return String containing the log information or empty string if no entries are available.
      */
     public String getLog(String deploymentId, Duration apiTimeout) {
-        logger.info("getLog:{}:{}", deploymentId, apiTimeout);
+        logger.debug("Retrieving log for deploymentId:{} with apiTimeout:{}", deploymentId, apiTimeout);
         Assert.hasText(deploymentId, "id must have text and not null");
         Assert.notNull(apiTimeout, "apiTimeout must not be null");
         StringBuilder stringBuilder = new StringBuilder();
         ReadRequest request = ReadRequest.builder().sourceId(deploymentId).build();
-        Assert.notNull(request, "request must not be null");
         List<Log> logs = this.logCacheClient
                 .read(request)
                 .flatMapMany(this::responseToEnvelope)

--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryAppDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.cloudfoundry.operations.applications.StartApplicationRequest;
 import org.cloudfoundry.operations.services.BindServiceInstanceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.yaml.snakeyaml.Yaml;
 import reactor.cache.CacheMono;
 import reactor.core.publisher.Flux;
@@ -212,7 +213,14 @@ public class CloudFoundryAppDeployer extends AbstractCloudFoundryDeployer implem
 
 	@Override
 	public String getLog(String id) {
-		return applicationLogAccessor.getLog(id, Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
+		AppStatus status = status(id);
+		String cfGuid = null;
+		for(Map.Entry<String, AppInstanceStatus> appInstanceStatus : status.getInstances().entrySet()) {
+			if(appInstanceStatus.getValue().getAttributes().containsKey("cf-guid")) {
+				cfGuid = appInstanceStatus.getValue().getAttributes().get("cf-guid");
+			}
+		}
+		return applicationLogAccessor.getLog(cfGuid, Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}
 
 	@Override

--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
@@ -133,7 +133,7 @@ public class CloudFoundryTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 	public String getLog(String id) {
 		TaskStatus taskStatus = this.status(id);
 		String appCfGuid = taskStatus.getAttributes().get("app-cf-guid");
-		logger.info("Retrieving log for app-guid-id {} for task-guid-id {}", appCfGuid, id);
+		logger.debug("Retrieving log for app-guid-id {} for task-guid-id {}", appCfGuid, id);
 		Assert.hasText(appCfGuid, "could not find a GUID app id for the task guid id " + id);
 		return this.applicationLogAccessor.getLog(appCfGuid,
 				Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));

--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryTaskLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
 import org.cloudfoundry.operations.applications.StopApplicationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -129,9 +131,13 @@ public class CloudFoundryTaskLauncher extends AbstractCloudFoundryTaskLauncher {
 
 	@Override
 	public String getLog(String id) {
-		return this.applicationLogAccessor.getLog(id, Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
+		TaskStatus taskStatus = this.status(id);
+		String appCfGuid = taskStatus.getAttributes().get("app-cf-guid");
+		logger.info("Retrieving log for app-guid-id {} for task-guid-id {}", appCfGuid, id);
+		Assert.hasText(appCfGuid, "could not find a GUID app id for the task guid id " + id);
+		return this.applicationLogAccessor.getLog(appCfGuid,
+				Duration.ofSeconds(this.deploymentProperties.getApiTimeout()));
 	}
-
 
 	/**
 	 * Set up a reactor flow to stage a task. Before staging check if the base


### PR DESCRIPTION
* Filters null envelopes from results.  This was causing the original failure from our update to use the `LogCacheClient`.
* Retrieve GUID from app instance for stream apps. 
* Update `AbstractCloudFoundryTaskLauncher` to add the `app-cf-guid` to the attributes for a task.
* Updated CloudFoundryTaskLauncher to use the `app-cf-guid` from the attributes and use this to retrieve logs from the `LogCacheClient`
* Add Tests