### PR TITLE
Override logback version to 1.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 		<spring-boot.version>2.7.18</spring-boot.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<modules>
@@ -101,6 +102,22 @@
 				<version>${kubernetes-fabric8-client.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!-- Override Logback provided by Spring Boot -->
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-core</artifactId>
+				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-access</artifactId>
+				<version>${logback.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This commit overrides the logback version in order to fix CVE-2023-6378.

https://github.com/spring-cloud/spring-cloud-dataflow/issues/5593


### Before changes
```
cbono@cbono-a01 spring-cloud-deployer % ./mvnw clean dependency:tree -Dincludes='ch.qos.logback' | grep -e  '1.2.12' | wc -l
      16
cbono@cbono-a01 spring-cloud-deployer % ./mvnw clean dependency:tree -Dincludes='ch.qos.logback' | grep -e  '1.2.13' | wc -l
       0
```

### After changes
```
cbono@cbono-a01 spring-cloud-deployer % ./mvnw clean dependency:tree -Dincludes='ch.qos.logback' | grep -e  '1.2.12' | wc -l
       0
cbono@cbono-a01 spring-cloud-deployer % ./mvnw clean dependency:tree -Dincludes='ch.qos.logback' | grep -e  '1.2.13' | wc -l
      16
```
