### PR TITLE
Return the latest logs

### DIFF
--- a/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessor.java
+++ b/spring-cloud-deployer-cloudfoundry/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessor.java
@@ -61,7 +61,7 @@ public class ApplicationLogAccessor {
         Assert.hasText(deploymentId, "id must have text and not null");
         Assert.notNull(apiTimeout, "apiTimeout must not be null");
         StringBuilder stringBuilder = new StringBuilder();
-        ReadRequest request = ReadRequest.builder().sourceId(deploymentId).limit(MAX_LOG_LIMIT).build();
+        ReadRequest request = ReadRequest.builder().sourceId(deploymentId).limit(MAX_LOG_LIMIT).descending(true).build();
         List<Log> logs = this.logCacheClient
                 .read(request)
                 .flatMapMany(this::responseToEnvelope)
@@ -75,8 +75,15 @@ public class ApplicationLogAccessor {
             stringBuilder.append(log.getPayloadAsText());
             stringBuilder.append(System.lineSeparator());
         });
-
-        return stringBuilder.toString();
+        String [] lines = stringBuilder.toString().split("\n");
+        StringBuilder stringBuilderReconstruct = new StringBuilder();
+        for(int i = lines.length -1  ; i >= 0  ; i--) {
+            stringBuilderReconstruct.append(lines[i]);
+            if ( i > 0 ) {
+                stringBuilderReconstruct.append("\n");
+            }
+        }
+        return stringBuilderReconstruct.toString();
     }
 
     private Flux<Log> responseToEnvelope(ReadResponse response) {

--- a/spring-cloud-deployer-cloudfoundry/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessorTests.java
+++ b/spring-cloud-deployer-cloudfoundry/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessorTests.java
@@ -42,8 +42,8 @@ public class ApplicationLogAccessorTests {
 
     @Test
     void testDefaultCase() {
-        final String sampleData = "foo\nbar\nbaz\nboo";
-        final String exectedResult = "boo\nbaz\nbar\nfoo";
+        String sampleData = "foo\nbar\nbaz\nboo";
+        String exectedResult = "boo\nbaz\nbar\nfoo";
         when(logCacheClient.read(any())).thenReturn(getSampleResponse(sampleData));
         ApplicationLogAccessor applicationLogAccessor = new ApplicationLogAccessor(this.logCacheClient);
         assertThat(applicationLogAccessor.getLog("myDeploymentId", Duration.ofSeconds(5))).isEqualTo(exectedResult);
@@ -54,6 +54,7 @@ public class ApplicationLogAccessorTests {
         EnvelopeBatch envelopeBatch = EnvelopeBatch.builder().batch(envelope).build();
         return Mono.just(ReadResponse.builder().envelopes(envelopeBatch).build());
     }
+
     private Log getSampleLog(String sampleData) {
         return Log.builder().payload(Base64.getEncoder().encodeToString(sampleData.getBytes())).build();
     }

--- a/spring-cloud-deployer-cloudfoundry/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessorTests.java
+++ b/spring-cloud-deployer-cloudfoundry/src/test/java/org/springframework/cloud/deployer/spi/cloudfoundry/ApplicationLogAccessorTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.cloudfoundry;
+
+import org.cloudfoundry.logcache.v1.Envelope;
+import org.cloudfoundry.logcache.v1.EnvelopeBatch;
+import org.cloudfoundry.logcache.v1.Log;
+import org.cloudfoundry.logcache.v1.LogCacheClient;
+import org.cloudfoundry.logcache.v1.ReadResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Base64;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ApplicationLogAccessorTests {
+
+    @Mock
+    private LogCacheClient logCacheClient;
+
+    @Test
+    void testDefaultCase() {
+        final String sampleData = "foo\nbar\nbaz\nboo";
+        final String exectedResult = "boo\nbaz\nbar\nfoo";
+        when(logCacheClient.read(any())).thenReturn(getSampleResponse(sampleData));
+        ApplicationLogAccessor applicationLogAccessor = new ApplicationLogAccessor(this.logCacheClient);
+        assertThat(applicationLogAccessor.getLog("myDeploymentId", Duration.ofSeconds(5))).isEqualTo(exectedResult);
+    }
+
+    private Mono<ReadResponse> getSampleResponse(String sampleData) {
+        Envelope envelope = Envelope.builder().log(getSampleLog(sampleData)).build();
+        EnvelopeBatch envelopeBatch = EnvelopeBatch.builder().batch(envelope).build();
+        return Mono.just(ReadResponse.builder().envelopes(envelopeBatch).build());
+    }
+    private Log getSampleLog(String sampleData) {
+        return Log.builder().payload(Base64.getEncoder().encodeToString(sampleData.getBytes())).build();
+    }
+}


### PR DESCRIPTION
The current log implementation returns the max limit of log envelopes from the start of the log.  However if a log exceeds this maximum the rest of the log is trimmed off.  In this case we retrieve the logs from the tail of the log to the maximum limit of log envelopes.

Also added missing tests for this class. 