### PR TITLE
K8s Task Launcher needs to be thread safe

### DIFF
--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -235,7 +235,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	}
 
 
-	private void launch(String appId, AppDeploymentRequest request) {
+	private synchronized void launch(String appId, AppDeploymentRequest request) {
 		Map<String, String> idMap = createIdMap(appId, request);
 		Map<String, String> podLabelMap = new HashMap<>();
 		podLabelMap.put("task-name", request.getDefinition().getName());


### PR DESCRIPTION
Launching task asynchronously can cause task method values to be overwritten when other threads launch at the same time.

In this solution we synchronize the launch method so that launches are thread safe