### PR TITLE
Extend timeouts in tests for deployments.

### DIFF
--- a/spring-cloud-deployer-kubernetes/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-kubernetes/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesTaskLauncherIntegrationTests.java
@@ -71,7 +71,7 @@ abstract class AbstractKubernetesTaskLauncherIntegrationTests extends AbstractTa
 
 	@Override
 	protected Timeout deploymentTimeout() {
-		return new Timeout(20, 5000);
+		return new Timeout(30, 5000);
 	}
 
 	@Test

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationJUnit5Tests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationJUnit5Tests.java
@@ -83,7 +83,7 @@ public abstract class AbstractSchedulerIntegrationJUnit5Tests {
 	 * Return the timeout to use for repeatedly querying that a task has been scheduled.
 	 * Default value is one minute, being queried every 5 seconds.
 	 */
-	private Timeout scheduleTimeout = new Timeout(12, 5000);
+	private Timeout scheduleTimeout = new Timeout(30, 5000);
 
 	/**
 	 * Return the timeout to use for repeatedly querying whether a task has been unscheduled.

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/scheduler/test/AbstractSchedulerIntegrationTests.java
@@ -83,7 +83,7 @@ public abstract class AbstractSchedulerIntegrationTests {
 	 * Return the timeout to use for repeatedly querying that a task has been scheduled.
 	 * Default value is one minute, being queried every 5 seconds.
 	 */
-	private Timeout scheduleTimeout = new Timeout(12, 5000);
+	private Timeout scheduleTimeout = new Timeout(30, 5000);
 
 	/**
 	 * Return the timeout to use for repeatedly querying whether a task has been unscheduled.

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationJUnit5Tests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationJUnit5Tests.java
@@ -80,7 +80,7 @@ public abstract class AbstractIntegrationJUnit5Tests {
 	 * @return the timeout
 	 */
 	protected Timeout deploymentTimeout() {
-		return new Timeout(12, 5000);
+		return new Timeout(30, 5000);
 	}
 
 	/**

--- a/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationTests.java
+++ b/spring-cloud-deployer-spi-test/src/main/java/org/springframework/cloud/deployer/spi/test/AbstractIntegrationTests.java
@@ -73,7 +73,7 @@ public abstract class AbstractIntegrationTests {
 	 * @return the deployment timeout value
 	 */
 	protected Timeout deploymentTimeout() {
-		return new Timeout(12, 5000);
+		return new Timeout(30, 5000);
 	}
 
 	/**


### PR DESCRIPTION
During local executions of tests that resolve remote artefacts the throttled download of repo.spring.io causes timeouts. 
Extending the timeouts saves people from going down rabbit holes.