### PR TITLE
[Local Deployer] [Docker] Added ability to add additional docker hosts

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -135,7 +135,7 @@ public class DockerCommandBuilder implements CommandBuilder {
 
 		applyPortMappings(commands,localDeployerProperties);
 		applyVolumeMountings(commands,localDeployerProperties);
-
+		applyAdditionalHosts(commands,localDeployerProperties);
 
 		if (request.getDeploymentProperties().containsKey(DOCKER_CONTAINER_NAME_KEY)) {
 			if (appInstanceNumber.isPresent()) {
@@ -172,6 +172,16 @@ public class DockerCommandBuilder implements CommandBuilder {
 		if (StringUtils.hasText(volumeMounts)) {
 			for (String v : parseMapping(volumeMounts)) {
 				commands.add("-v");
+				commands.add(v);
+			}
+		}
+	}
+
+	private void applyAdditionalHosts(List<String> commands, LocalDeployerProperties localDeployerProperties) {
+		String additionalHosts = localDeployerProperties.getDocker().getAdditionalHosts();
+		if (StringUtils.hasText(additionalHosts)) {
+			for (String v : parseMapping(additionalHosts)) {
+				commands.add("--add-host");
 				commands.add(v);
 			}
 		}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -311,6 +311,11 @@ public class LocalDeployerProperties {
 		 */
 		private String volumeMounts;
 
+		/**
+		 * Set additional hosts
+		 */
+		private String additionalHosts;
+
 		public PortRange getPortRange() {
 			return portRange;
 		}
@@ -346,6 +351,10 @@ public class LocalDeployerProperties {
 		public void setVolumeMounts(String volumeMounts) {
 			this.volumeMounts = volumeMounts;
 		}
+
+		public String getAdditionalHosts() { return additionalHosts; }
+
+		public void setAdditionalHosts(String additionalHosts) { this.additionalHosts = additionalHosts; }
 
 		@Override
 		public int hashCode() {

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
@@ -160,4 +160,24 @@ public class DockerCommandBuilderTests {
 		assertThat(builder.command()).contains(goodMapping1, goodMapping2);
 		assertThat(builder.command()).doesNotContain(incompleteMapping);
 	}
+
+	@Test
+	public void  testContainerAdditionalHost(){
+		AppDefinition appDefinition = new AppDefinition("foo", null);
+		Resource resource = new DockerResource("foo/bar");
+		Map<String, String> deploymentProperties = Collections.emptyMap();
+		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
+
+		String goodMapping1 = "host.docker.internal:host-gateway";
+		String incompleteMapping = "host.docker.internal";
+		LocalDeployerProperties localDeployerProperties = new LocalDeployerProperties();
+		localDeployerProperties.getDocker().setAdditionalHosts(goodMapping1 + "," + incompleteMapping);
+
+		ProcessBuilder builder = new DockerCommandBuilder("scdf_default")
+				.buildExecutionCommand(request, new HashMap<>(), "deployerId", Optional.of(1),
+						localDeployerProperties, Optional.empty());
+
+		assertThat(builder.command()).contains(goodMapping1);
+		assertThat(builder.command()).doesNotContain(incompleteMapping);
+	}
 }


### PR DESCRIPTION
Hello

I need to use an `host.docker.internal` alias inside docker containers deployed using the Local Deployer to reach services deployed on the host machine for development purposes. Unfortunately this alias does not working out of the box even if a container is attached to a docker network. It requires to pass an `--add-host` to the `docker run` command but Local deployer does not have ability to do it.

So, I created this PR to add ability to define additional host aliases that extends the `DockerCommandBuilder` for proper passing it to the `docker run` command.