### PR TITLE
Add dep. mgmt. for commons-io and commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
 		<maven.version>3.6.2</maven.version>
 		<maven-resolver.version>1.4.1</maven-resolver.version>
 		<maven-wagon.version>3.5.2</maven-wagon.version>
-		<commons-io.version>2.7</commons-io.version>
+		<commons-compress.version>1.26.1</commons-compress.version>
+		<commons-io.version>2.15.1</commons-io.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>
 		<spring-boot.version>2.7.18</spring-boot.version>
 		<spring-framework.version>5.3.34</spring-framework.version>
@@ -109,6 +110,16 @@
 				<version>${kubernetes-fabric8-client.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${commons-io.version}</version>
 			</dependency>
 			<!-- Override Logback provided by Spring Boot -->
 			<dependency>

--- a/spring-cloud-deployer-cloudfoundry/pom.xml
+++ b/spring-cloud-deployer-cloudfoundry/pom.xml
@@ -17,7 +17,6 @@
 		<java.version>1.8</java.version>
 		<cloudfoundry-java-lib.version>4.16.0.RELEASE</cloudfoundry-java-lib.version>
 		<pivotal-cf-client-reactor.version>2.2.0.RELEASE</pivotal-cf-client-reactor.version>
-		<commons-compress.version>1.26.0</commons-compress.version>
 		<okhttp.version>3.14.9</okhttp.version>
 	</properties>
 
@@ -48,7 +47,6 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>${commons-compress.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cloudfoundry</groupId>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -56,7 +56,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
A previous update to commons-compress 1.26.0 introduced a requirement to use commons-io 2.15.1 but there was a version 2.7.x being pulled in by maven resource module. 
This commit adds dependency management to all deployer modules so that these libs stay in sync.