### PR TITLE
[DO NOT MERGE] Node-Selector id format needs to match the other properties

### DIFF
--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -51,7 +51,7 @@ public class KubernetesDeployerProperties {
      * Constants for app deployment properties that don't have a deployer level default
      * property.
      */
-    static final String KUBERNETES_DEPLOYMENT_NODE_SELECTOR = "spring.cloud.deployer.kubernetes.deployment.nodeSelector";
+    static final String KUBERNETES_DEPLOYMENT_NODE_SELECTOR = "spring.cloud.deployer.kubernetes.node-selector";
 
     /**
      * The maximum concurrent tasks allowed for this platform instance.


### PR DESCRIPTION
The id as it is used in the deployer is not correct.  The constant needed to be updated.

Do not merge until after 2.9.4 is released