### PR TITLE
Put dependency versions in properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 		<logback.version>1.2.13</logback.version>
 		<json-path.version>2.9.0</json-path.version>
 		<jackson-bom.version>2.17.1</jackson-bom.version>
+		<snakeyaml.version>1.33</snakeyaml.version>
 	</properties>
 
 	<modules>
@@ -88,7 +89,7 @@
 			<dependency>
 				<groupId>org.yaml</groupId>
 				<artifactId>snakeyaml</artifactId>
-				<version>1.33</version>
+				<version>${snakeyaml.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<logback.version>1.2.13</logback.version>
 		<json-path.version>2.9.0</json-path.version>
 		<okio.version>3.4.0</okio.version>
-		<jackson-bom.version>2.17.1</jackson-bom.version>
+		<jackson-bom.version>2.17.2</jackson-bom.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<logback.version>1.2.13</logback.version>
 		<json-path.version>2.9.0</json-path.version>
+		<okio.version>3.4.0</okio.version>
 		<jackson-bom.version>2.17.1</jackson-bom.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 	</properties>
@@ -99,7 +100,7 @@
 			<dependency>
 				<groupId>com.squareup.okio</groupId>
 				<artifactId>okio</artifactId>
-				<version>3.4.0</version>
+				<version>${okio.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.fabric8</groupId>


### PR DESCRIPTION
This PR updates Jackson to 2.17.2 as well as moves a few version numbers into Maven properties rather than being specified in the middle of the pom.xml.