### PR TITLE
Cleanup dependencies in pom.xmls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,17 @@
 		<!-- @TODO boot3 waiting for 4.x to support jakarta ee -->
 		<maven-resolver.version>1.9.18</maven-resolver.version>
 		<maven-wagon.version>3.5.3</maven-wagon.version>
-        <commons-compress.version>1.26.1</commons-compress.version>
-        <commons-io.version>2.16.1</commons-io.version>
+		<commons-compress.version>1.26.2</commons-compress.version>
+		<commons-io.version>2.16.1</commons-io.version>
 		<kubernetes-fabric8-client.version>6.9.2</kubernetes-fabric8-client.version>
-		<spring-boot.version>3.3.0</spring-boot.version>
-		<spring-framework.version>6.1.8</spring-framework.version>
+		<spring-boot.version>3.3.4</spring-boot.version>
+		<spring-framework.version>6.1.13</spring-framework.version>
+		<hashids.version>1.0.1</hashids.version>
+		<!-- @TODO boot3 updates need for jakarta ee -->
+		<cloudfoundry-java-lib.version>5.12.1.RELEASE</cloudfoundry-java-lib.version>
+		<pivotal-cf-client-reactor.version>2.2.0.RELEASE</pivotal-cf-client-reactor.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<json-path.version>2.9.0</json-path.version>
 	</properties>
 
 	<modules>
@@ -85,11 +88,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-            <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${json-path.version}</version>
-            </dependency>
 			<dependency>
 				<groupId>io.fabric8</groupId>
 				<artifactId>kubernetes-client-bom</artifactId>
@@ -125,6 +123,21 @@
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-http</artifactId>
 				<version>${maven-wagon.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.cloudfoundry</groupId>
+				<artifactId>cloudfoundry-client-reactor</artifactId>
+				<version>${cloudfoundry-java-lib.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.cloudfoundry</groupId>
+				<artifactId>cloudfoundry-operations</artifactId>
+				<version>${cloudfoundry-java-lib.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.pivotal</groupId>
+				<artifactId>pivotal-cloudfoundry-client-reactor</artifactId>
+				<version>${pivotal-cf-client-reactor.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,7 @@
 		<!-- ==================== -->
 		<!-- Dependency Versions  -->
 		<!-- ==================== -->
-		<spring-boot.version>3.3.4</spring-boot.version>
-		<spring-framework.version>6.1.13</spring-framework.version>
+		<spring-boot.version>3.3.5</spring-boot.version>
 		<commons-compress.version>1.26.2</commons-compress.version>
 		<commons-io.version>2.16.1</commons-io.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,22 +53,32 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>
+
+		<!-- ==================== -->
+		<!-- Dependency Versions  -->
+		<!-- ==================== -->
+		<spring-boot.version>3.3.4</spring-boot.version>
+		<spring-framework.version>6.1.13</spring-framework.version>
+		<commons-compress.version>1.26.2</commons-compress.version>
+		<commons-io.version>2.16.1</commons-io.version>
+
+		<!-- Kubernetes Deployer -->
+		<kubernetes-fabric8-client.version>6.9.2</kubernetes-fabric8-client.version>
+		<hashids.version>1.0.1</hashids.version>
+
+		<!-- Cloudfoundry Deployer -->
+		<!-- @TODO boot3 updates need for jakarta ee -->
+		<cloudfoundry-java-lib.version>5.12.1.RELEASE</cloudfoundry-java-lib.version>
+		<pivotal-cf-client-reactor.version>2.2.0.RELEASE</pivotal-cf-client-reactor.version>
+
+		<!-- ==================== -->
+		<!-- Plugin Versions      -->
+		<!-- ==================== -->
 		<!-- @TODO boot3 waiting for 4.x to support jakarta ee -->
 		<maven.version>3.9.6</maven.version>
 		<!-- @TODO boot3 waiting for 4.x to support jakarta ee -->
 		<maven-resolver.version>1.9.18</maven-resolver.version>
 		<maven-wagon.version>3.5.3</maven-wagon.version>
-		<commons-compress.version>1.26.2</commons-compress.version>
-		<commons-io.version>2.16.1</commons-io.version>
-		<kubernetes-fabric8-client.version>6.9.2</kubernetes-fabric8-client.version>
-		<spring-boot.version>3.3.4</spring-boot.version>
-		<spring-framework.version>6.1.13</spring-framework.version>
-		<hashids.version>1.0.1</hashids.version>
-		<!-- @TODO boot3 updates need for jakarta ee -->
-		<cloudfoundry-java-lib.version>5.12.1.RELEASE</cloudfoundry-java-lib.version>
-		<pivotal-cf-client-reactor.version>2.2.0.RELEASE</pivotal-cf-client-reactor.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
 	</properties>
 
 	<modules>

--- a/spring-cloud-deployer-cloudfoundry/pom.xml
+++ b/spring-cloud-deployer-cloudfoundry/pom.xml
@@ -13,20 +13,10 @@
 		<relativePath>..</relativePath>
 	</parent>
 
-	<properties>
-		<java.version>17</java.version>
-		<!-- @TODO boot3 updates need for jakarta ee -->
-		<cloudfoundry-java-lib.version>5.12.1.RELEASE</cloudfoundry-java-lib.version>
-		<pivotal-cf-client-reactor.version>2.2.0.RELEASE</pivotal-cf-client-reactor.version>
-		<commons-compress.version>1.26.2</commons-compress.version>
-        <okhttp.version>3.14.9</okhttp.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -44,7 +34,6 @@
 		<dependency>
 			<groupId>org.cloudfoundry</groupId>
 			<artifactId>cloudfoundry-client-reactor</artifactId>
-			<version>${cloudfoundry-java-lib.version}</version>
 			<!-- @TODO boot3 remove when updated -->
 			<exclusions>
 				<exclusion>
@@ -54,14 +43,16 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-compress</artifactId>
-			<version>${commons-compress.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.cloudfoundry</groupId>
 			<artifactId>cloudfoundry-operations</artifactId>
-			<version>${cloudfoundry-java-lib.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.pivotal</groupId>
+			<artifactId>pivotal-cloudfoundry-client-reactor</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
@@ -74,11 +65,6 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.pivotal</groupId>
-			<artifactId>pivotal-cloudfoundry-client-reactor</artifactId>
-			<version>${pivotal-cf-client-reactor.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.retry</groupId>
@@ -98,31 +84,26 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
-			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-support</artifactId>
-			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-autoconfigure</artifactId>
-			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-deployer-kubernetes/pom.xml
+++ b/spring-cloud-deployer-kubernetes/pom.xml
@@ -15,23 +15,18 @@
 	</parent>
 
 	<properties>
-		<java.version>17</java.version>
-		<java-semver.version>0.9.0</java-semver.version>
-		<maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+		<!-- TODO remove this when spring-cloud-deployer/issues/484 is complete -->
 		<powermock.version>2.0.2</powermock.version>
 	</properties>
-
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -48,7 +43,7 @@
 		<dependency>
 			<groupId>org.hashids</groupId>
 			<artifactId>hashids</artifactId>
-			<version>1.0.1</version>
+			<version>${hashids.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -76,7 +71,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.23.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-deployer-local/pom.xml
+++ b/spring-cloud-deployer-local/pom.xml
@@ -17,17 +17,14 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-deployer-resource-maven/pom.xml
+++ b/spring-cloud-deployer-resource-maven/pom.xml
@@ -70,7 +70,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>

--- a/spring-cloud-deployer-spi-test/pom.xml
+++ b/spring-cloud-deployer-spi-test/pom.xml
@@ -34,12 +34,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -59,8 +57,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>${hamcrest.version}</version>
+			<artifactId>hamcrest-library</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.awaitility</groupId>


### PR DESCRIPTION
This commit does the following:
- Removes versions on dependencies that are already managed by boot
- Pulls all version numbers into the root pom.xml
- Removes all unused properties and dependencies

> [!NOTE]
> I reformatted the root pom.xml in commit 2) if you want to see the version changes look at commit 1) first.