### PR TITLE
[CI] Update jfrog cli to v3

### DIFF
--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -19,7 +19,8 @@ jobs:
         distribution: 'liberica'
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # cache maven .m2
     - uses: actions/cache@v3
@@ -33,8 +34,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc --use-wrapper \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,14 @@ jobs:
     # jfrog cli
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     # setup frog cli
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc --use-wrapper \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -19,7 +19,8 @@ jobs:
         distribution: 'liberica'
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
@@ -31,8 +32,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc --use-wrapper \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-milestone-local \

--- a/.github/workflows/next-dev-version-worker.yml
+++ b/.github/workflows/next-dev-version-worker.yml
@@ -19,7 +19,8 @@ jobs:
         distribution: 'liberica'
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # cache maven .m2
     - uses: actions/cache@v3
@@ -33,8 +34,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc --use-wrapper \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -19,7 +19,8 @@ jobs:
         distribution: 'liberica'
     - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
@@ -31,8 +32,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc --use-wrapper \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-release-staging \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-staging-local \


### PR DESCRIPTION
Update setup-jfrog-cli to use `JF_ENV_SPRING` instead of `JF_ARTIFACTORY_SPRING` 
Added `JF_URL`
Added reference to `${{ vars.JF_SERVER_ID }}` in place of `repo.spring.io`