### PR TITLE
Update PR 501 and apply changes for merge

### DIFF
--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -181,16 +181,15 @@ class DeploymentPropertiesResolver {
 		if (StringUtils.hasText(cpu)) {
 			limits.put("cpu", new Quantity(cpu));
 		}
-
-		if (StringUtils.hasText(ephemeralStorage)) {
+		if(StringUtils.hasText(ephemeralStorage)) {
 			limits.put("ephemeral-storage", new Quantity(ephemeralStorage));
 		}
 
-		if (StringUtils.hasText(hugePages2Mi)) {
+		if(StringUtils.hasText(hugePages2Mi)) {
 			limits.put("hugepages-2Mi", new Quantity(hugePages2Mi));
 		}
 
-		if (StringUtils.hasText(hugePages1Gi)) {
+		if(StringUtils.hasText(hugePages1Gi)) {
 			limits.put("hugepages-1Gi", new Quantity(hugePages1Gi));
 		}
 

--- a/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/spring-cloud-deployer-kubernetes/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -218,7 +218,7 @@ public class KubernetesDeployerProperties {
          */
         private String ephemeralStorage;
 
-        /**
+		/**
          * Container resource hugepages-2Mi request.
          */
         private String hugepages2Mi;
@@ -232,20 +232,7 @@ public class KubernetesDeployerProperties {
         public RequestsResources() {
         }
 
-        /**
-         * 'All' args constructor
-         *
-         * @param cpu    Container resource requested cpu
-         * @param memory Container resource requested memory
-         * @deprecated This method should no longer be used to set all fields at construct time.
-         * <p>
-         * Use the default constructor and set() methods instead.
-         */
-        @Deprecated
-        public RequestsResources(String cpu, String memory) {
-            this.cpu = cpu;
-            this.memory = memory;
-        }
+
         @Deprecated
         public RequestsResources(String cpu, String memory, String ephemeralStorage, String hugepages2Mi, String hugepages1Gi) {
             this.cpu = cpu;
@@ -1652,97 +1639,6 @@ public class KubernetesDeployerProperties {
         this.priorityClassName = priorityClassName;
     }
 
-    /**
-     * @deprecated
-	 * @see #getLivenessHttpProbeDelay()
-     */
-    @Deprecated
-    public int getLivenessProbeDelay() {
-        return livenessHttpProbeDelay;
-    }
-
-    /**
-     * @deprecated
-	 * @see #setLivenessHttpProbeDelay(int)
-     */
-    @Deprecated
-    public void setLivenessProbeDelay(int livenessProbeDelay) {
-        this.livenessHttpProbeDelay = livenessProbeDelay;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getLivenessHttpProbePeriod()
-     */
-    @Deprecated
-    public int getLivenessProbePeriod() {
-        return livenessHttpProbePeriod;
-    }
-
-    /**
-     * @deprecated
-	 * @see #setLivenessHttpProbePeriod(int)
-     */
-    @Deprecated
-    public void setLivenessProbePeriod(int livenessProbePeriod) {
-        this.livenessHttpProbePeriod = livenessProbePeriod;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getLivenessHttpProbeTimeout()
-     */
-    @Deprecated
-    public int getLivenessProbeTimeout() {
-        return livenessHttpProbeTimeout;
-    }
-
-    /**
-     * @deprecated
-	 * @see #setLivenessHttpProbeTimeout(int)
-     */
-    @Deprecated
-    public void setLivenessProbeTimeout(int livenessProbeTimeout) {
-        this.livenessHttpProbeTimeout = livenessProbeTimeout;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getLivenessHttpProbePath()
-     */
-    @Deprecated
-    public String getLivenessProbePath() {
-        return livenessHttpProbePath;
-    }
-
-    /**
-     * @deprecated
-	 * @see #setLivenessHttpProbePath(String)
-     */
-    @Deprecated
-    public void setLivenessProbePath(String livenessProbePath) {
-        this.livenessHttpProbePath = livenessProbePath;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getLivenessHttpProbePort()
-     */
-    @Deprecated
-    public Integer getLivenessProbePort() {
-        return livenessHttpProbePort;
-    }
-
-    /**
-     * @deprecated
-	 * @see #setLivenessHttpProbePort(Integer)
-     */
-    @Deprecated
-    public void setLivenessProbePort(Integer livenessProbePort) {
-        this.livenessHttpProbePort = livenessProbePort;
-    }
-
-
     public int getLivenessTcpProbeSuccess() {
         return livenessTcpProbeSuccess;
     }
@@ -2033,36 +1929,6 @@ public class KubernetesDeployerProperties {
         this.startupCommandProbeCommand = startupCommandProbeCommand;
     }
 
-    /**
-     * @deprecated
-	 * @see #getReadinessHttpProbeDelay()
-	 * @return the probe delay
-     */
-    @Deprecated
-    public int getReadinessProbeDelay() {
-        return readinessHttpProbeDelay;
-    }
-
-    /**
-     * @deprecated
-	 * @param readinessProbeDelay the probe delay
-	 * @see #setReadinessHttpProbeDelay(int)
-     */
-    @Deprecated
-    public void setReadinessProbeDelay(int readinessProbeDelay) {
-        this.readinessHttpProbeDelay = readinessProbeDelay;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getReadinessHttpProbePeriod()
-	 * @return the probe period
-     */
-    @Deprecated
-    public int getReadinessProbePeriod() {
-        return readinessHttpProbePeriod;
-    }
-
     public int getReadinessTcpProbeFailure() {
         return readinessTcpProbeFailure;
     }
@@ -2114,76 +1980,6 @@ public class KubernetesDeployerProperties {
 
     public void setReadinessCommandProbeSuccess(int readinessCommandProbeSuccess) {
         this.readinessCommandProbeSuccess = readinessCommandProbeSuccess;
-    }
-
-    /**
-     * @deprecated
-	 * @param readinessProbePeriod the period
-	 * @see #setReadinessHttpProbePeriod(int)
-     */
-    @Deprecated
-    public void setReadinessProbePeriod(int readinessProbePeriod) {
-        this.readinessHttpProbePeriod = readinessProbePeriod;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getReadinessHttpProbeTimeout()
-	 * @return the timeout
-     */
-    @Deprecated
-    public int getReadinessProbeTimeout() {
-        return readinessHttpProbeTimeout;
-    }
-
-    /**
-     * @deprecated
-	 * @param readinessProbeTimeout the timeout of the probe
-	 * @see #setReadinessHttpProbeTimeout(int)
-     */
-    @Deprecated
-    public void setReadinessProbeTimeout(int readinessProbeTimeout) {
-        this.readinessHttpProbeTimeout = readinessProbeTimeout;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getReadinessHttpProbePath()
-	 * @return the path
-     */
-    @Deprecated
-    public String getReadinessProbePath() {
-        return readinessHttpProbePath;
-    }
-
-    /**
-     * @deprecated
-	 * @param readinessProbePath the path to use for http request
-	 * @see #setReadinessHttpProbePath(String)
-     */
-    @Deprecated
-    public void setReadinessProbePath(String readinessProbePath) {
-        this.readinessHttpProbePath = readinessProbePath;
-    }
-
-    /**
-     * @deprecated
-	 * @see #getReadinessHttpProbePort()
-	 * @return the port of the probe
-     */
-    @Deprecated
-    public Integer getReadinessProbePort() {
-        return readinessHttpProbePort;
-    }
-
-    /**
-     * @deprecated
-	 * @param readinessProbePort the port number use by the probe
-	 * @see #setReadinessHttpProbePort(Integer)
-     */
-    @Deprecated
-    public void setReadinessProbePort(Integer readinessProbePort) {
-        this.readinessHttpProbePort = readinessProbePort;
     }
 
     public int getReadinessHttpProbeDelay() {

--- a/spring-cloud-deployer-kubernetes/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/spring-cloud-deployer-kubernetes/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -313,7 +313,7 @@ public class DefaultContainerFactoryTests {
     @Deprecated
     public void createCustomLivenessPortFromProperties() {
         KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-        kubernetesDeployerProperties.setLivenessProbePort(8090);
+        kubernetesDeployerProperties.setLivenessHttpProbePort(8090);
         DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
                 kubernetesDeployerProperties);
 
@@ -593,7 +593,7 @@ public class DefaultContainerFactoryTests {
     @Deprecated
     public void createCustomReadinessPortFromProperties() {
         KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-        kubernetesDeployerProperties.setReadinessProbePort(8090);
+        kubernetesDeployerProperties.setReadinessHttpProbePort(8090);
         DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
                 kubernetesDeployerProperties);
 
@@ -809,8 +809,8 @@ public class DefaultContainerFactoryTests {
     @Deprecated
     public void createProbesWithPropertyOverrides() {
         KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-        kubernetesDeployerProperties.setReadinessProbePath("/readiness");
-        kubernetesDeployerProperties.setLivenessProbePath("/liveness");
+        kubernetesDeployerProperties.setReadinessHttpProbePath("/readiness");
+        kubernetesDeployerProperties.setLivenessHttpProbePath("/liveness");
         DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
                 kubernetesDeployerProperties);
 


### PR DESCRIPTION
Adds missing ephemeral storeagew and hugepages properties.

See #500

Fix missing ephemeral storeage and hugepages properties

Removes deprecated methods in relevant files.

See #500

Fix missing ephemeral storeage and hugepages properties

Fixes test that used deprecated methods.

See #500

Fix missing ephemeral storeage and hugepages properties.

See https://github.com/spring-cloud/spring-cloud-deployer/issues/500

Fix missing ephemeral storeage and hugepages properties.

Fix formatting.

Fix missing ephemeral storeage and hugepages properties.

Revert LimitsResources constructor to deprecated version.

Fix missing ephemeral storeage and hugepages properties.

Revert RequestsResources constructor to previous version and mark as deprecated.

Added extra all args constructors.
Documented and updated gpuVendor usage. According to documentation there is no common format for the gpu vendor string and it has to be provided as needed.

Remove resolve from JFrog-CLI to have it resolve depedencies from settings and pom files



Update gpu based tests in RunAbstractKubernetesDeployerTests

It was determined that our addition of /gpu in limit determination was incorrect.  meaning it is not standard. The tests were not updated based on this code change.  This commit resolves this



Remove deprecated constructors from KubernetesDeployerProperties.

One deprecation was in error and removed from this PR.